### PR TITLE
Test: cancel form should clear existing values

### DIFF
--- a/playwright-tests/tests/payments/create-payment-request.spec.js
+++ b/playwright-tests/tests/payments/create-payment-request.spec.js
@@ -46,10 +46,9 @@ async function fillCreateForm(page, daoAccount, instanceAccount) {
   await totalAmountField.pressSequentially("3");
   await totalAmountField.blur();
 
-  // TODO: add this back as soon as we have the pikespeak key for infinex
-  // const tokenSelect = await page.getByTestId("tokens-dropdown");
-  // await tokenSelect.click();
-  // await tokenSelect.getByText("NEAR").click();
+  const tokenSelect = await page.getByTestId("tokens-dropdown");
+  await tokenSelect.click();
+  await tokenSelect.getByText("NEAR").click();
 }
 
 test.describe("admin connected", function () {

--- a/playwright-tests/tests/payments/create-payment-request.spec.js
+++ b/playwright-tests/tests/payments/create-payment-request.spec.js
@@ -75,23 +75,16 @@ test.describe("admin connected", function () {
       .getByRole("button", { name: "Cancel" });
     await expect(cancelBtn).toBeAttached({ timeout: 10_000 });
 
-    // await cancelBtn.waitFor({ state: "attached", timeout: 10_000 });
-    // await cancelBtn.scrollIntoViewIfNeeded({ timeout: 10_000 });
     cancelBtn.click();
     await page.getByRole("button", { name: "Yes" }).click();
 
     await clickCreatePaymentRequestButton(page);
 
-    await expect(await page.getByTestId("proposal-title").inputValue()).toBe(
-      ""
-    );
-    await expect(await page.getByTestId("proposal-summary").inputValue()).toBe(
-      ""
-    );
-    await expect(
-      await page.getByPlaceholder("treasury.near").inputValue()
-    ).toBe("");
-    await expect(await page.getByTestId("total-amount").inputValue()).toBe("");
+    // TODO: add a case where the form is a proposal selection instead of a manual title and summary
+    expect(await page.getByTestId("proposal-title").inputValue()).toBe("");
+    expect(await page.getByTestId("proposal-summary").inputValue()).toBe("");
+    expect(await page.getByPlaceholder("treasury.near").inputValue()).toBe("");
+    expect(await page.getByTestId("total-amount").inputValue()).toBe("");
   });
 
   test("create manual payment request", async ({

--- a/playwright-tests/tests/payments/create-payment-request.spec.js
+++ b/playwright-tests/tests/payments/create-payment-request.spec.js
@@ -10,16 +10,21 @@ import { setDontAskAgainCacheValues } from "../../util/cache";
 import { getInstanceConfig } from "../../util/config.js";
 import { mockInventory } from "../../util/inventory.js";
 
-async function fillCreateForm(page, daoAccount, instanceAccount) {
-  await mockInventory({ page, account: daoAccount });
-  const instanceConfig = await getInstanceConfig({ page, instanceAccount });
-  await page.goto(`/${instanceAccount}/widget/app?page=payments`);
-
+async function clickCreatePaymentRequestButton(page) {
   const createPaymentRequestButton = await page.getByRole("button", {
     name: "Create Request",
   });
   await expect(createPaymentRequestButton).toBeVisible();
   await createPaymentRequestButton.click();
+  return createPaymentRequestButton;
+}
+
+async function fillCreateForm(page, daoAccount, instanceAccount) {
+  await mockInventory({ page, account: daoAccount });
+  const instanceConfig = await getInstanceConfig({ page, instanceAccount });
+  await page.goto(`/${instanceAccount}/widget/app?page=payments`);
+
+  await clickCreatePaymentRequestButton(page);
 
   if (instanceConfig.showProposalSelection === true) {
     const proposalSelect = await page.locator(".dropdown-toggle").first();
@@ -41,9 +46,10 @@ async function fillCreateForm(page, daoAccount, instanceAccount) {
   await totalAmountField.pressSequentially("3");
   await totalAmountField.blur();
 
-  const tokenSelect = await page.getByTestId("tokens-dropdown");
-  await tokenSelect.click();
-  await tokenSelect.getByText("NEAR").click();
+  // TODO: add this back as soon as we have the pikespeak key for infinex
+  // const tokenSelect = await page.getByTestId("tokens-dropdown");
+  // await tokenSelect.click();
+  // await tokenSelect.getByText("NEAR").click();
 }
 
 test.describe("admin connected", function () {
@@ -58,13 +64,36 @@ test.describe("admin connected", function () {
   // }) => {
   // });
 
-  // test("cancel form should clear existing values", async ({
-  //   page,
-  //   instanceAccount,
-  //   daoAccount,
-  // }) => {
-  //   test.setTimeout(60_000);
-  // });
+  test("cancel form should clear existing values", async ({
+    page,
+    instanceAccount,
+    daoAccount,
+  }) => {
+    test.setTimeout(60_000);
+    await fillCreateForm(page, daoAccount, instanceAccount);
+    const cancelBtn = page
+      .locator(".offcanvas-body")
+      .getByRole("button", { name: "Cancel" });
+    await expect(cancelBtn).toBeAttached({ timeout: 10_000 });
+
+    // await cancelBtn.waitFor({ state: "attached", timeout: 10_000 });
+    // await cancelBtn.scrollIntoViewIfNeeded({ timeout: 10_000 });
+    cancelBtn.click();
+    await page.getByRole("button", { name: "Yes" }).click();
+
+    await clickCreatePaymentRequestButton(page);
+
+    await expect(await page.getByTestId("proposal-title").inputValue()).toBe(
+      ""
+    );
+    await expect(await page.getByTestId("proposal-summary").inputValue()).toBe(
+      ""
+    );
+    await expect(
+      await page.getByPlaceholder("treasury.near").inputValue()
+    ).toBe("");
+    await expect(await page.getByTestId("total-amount").inputValue()).toBe("");
+  });
 
   test("create manual payment request", async ({
     page,
@@ -78,7 +107,7 @@ test.describe("admin connected", function () {
       .getByRole("button", { name: "Submit" });
     await expect(submitBtn).toBeAttached({ timeout: 10_000 });
     await submitBtn.scrollIntoViewIfNeeded({ timeout: 10_000 });
-    submitBtn.click();
+    await submitBtn.click();
 
     await expect(await getTransactionModalObject(page)).toEqual({
       proposal: {
@@ -123,12 +152,7 @@ test.describe("admin connected", function () {
     );
     await page.goto(`/${instanceAccount}/widget/app?page=payments`);
 
-    const createPaymentRequestButton = await page.getByRole("button", {
-      name: "Create Request",
-    });
-
-    await expect(createPaymentRequestButton).toBeVisible();
-    await createPaymentRequestButton.click();
+    await clickCreatePaymentRequestButton(page);
 
     const amountFromLinkedProposal = 3120 / nearPrice;
 
@@ -169,7 +193,7 @@ test.describe("admin connected", function () {
     const submitBtn = page.getByRole("button", { name: "Submit" });
     await expect(submitBtn).toBeAttached({ timeout: 10_000 });
     await submitBtn.scrollIntoViewIfNeeded({ timeout: 10_000 });
-    submitBtn.click();
+    await submitBtn.click();
 
     const expectedTransactionModalObject = instanceConfig.showProposalSelection
       ? {
@@ -215,11 +239,7 @@ test.describe("admin connected", function () {
     await mockInventory({ page, account: daoAccount });
     await page.goto(`/${instanceAccount}/widget/app?page=payments`);
 
-    const createPaymentRequestButton = await page.getByRole("button", {
-      name: "Create Request",
-    });
-    await expect(createPaymentRequestButton).toBeVisible();
-    await createPaymentRequestButton.click();
+    await clickCreatePaymentRequestButton(page);
 
     if (instanceConfig.showProposalSelection === true) {
       const proposalSelect = await page.locator(".dropdown-toggle").first();
@@ -262,7 +282,7 @@ test.describe("admin connected", function () {
     const submitBtn = page.getByRole("button", { name: "Submit" });
     await expect(submitBtn).toBeAttached({ timeout: 10_000 });
     await submitBtn.scrollIntoViewIfNeeded({ timeout: 10_000 });
-    submitBtn.click();
+    await submitBtn.click();
 
     const expectedTransactionModalObject = instanceConfig.showProposalSelection
       ? {


### PR DESCRIPTION
This PR adds a single test to make sure the inputs get cleared once a users clicks cancel after starting the create payment request flow has started.