### PR TITLE
check that payment requests appear in pending requests after submission

### DIFF
--- a/playwright-tests/tests/payments/create-payment-request.spec.js
+++ b/playwright-tests/tests/payments/create-payment-request.spec.js
@@ -330,6 +330,37 @@ test.describe("admin connected", function () {
     await expect(firstRow).toContainText(
       expectedTransactionModalObject.proposal.kind.Transfer.receiver_id
     );
+
+    const checkThatFormIsCleared = async () => {
+      await page.getByRole("button", { name: " Create Request" }).click();
+
+      if (instanceConfig.showProposalSelection === true) {
+        const proposalSelect = await page.locator(".dropdown-toggle").first();
+        await expect(proposalSelect).toBeVisible();
+
+        await expect(
+          await proposalSelect.getByText("Select", { exact: true })
+        ).toBeVisible();
+      } else {
+        await expect(await page.getByTestId("proposal-title")).toHaveText("");
+        await expect(await page.getByTestId("proposal-summary")).toHaveText("");
+
+        await expect(
+          await page.getByPlaceholder("treasury.near")
+        ).toBeVisible();
+
+        await expect(await page.getByTestId("total-amount")).toHaveText("");
+      }
+      const submitBtn = page.getByRole("button", { name: "Submit" });
+      await expect(submitBtn).toBeAttached({ timeout: 10_000 });
+      await submitBtn.scrollIntoViewIfNeeded({ timeout: 10_000 });
+      await expect(submitBtn).toBeDisabled({ timeout: 10_000 });
+    };
+    await checkThatFormIsCleared();
+
+    await page.reload();
+
+    await checkThatFormIsCleared();
   });
 
   test("create USDC transfer payment request", async ({

--- a/playwright-tests/tests/payments/create-payment-request.spec.js
+++ b/playwright-tests/tests/payments/create-payment-request.spec.js
@@ -14,7 +14,7 @@ async function clickCreatePaymentRequestButton(page) {
   const createPaymentRequestButton = await page.getByRole("button", {
     name: "Create Request",
   });
-  await expect(createPaymentRequestButton).toBeVisible();
+  await expect(createPaymentRequestButton).toBeVisible({timeout: 10_000});
   await createPaymentRequestButton.click();
   return createPaymentRequestButton;
 }
@@ -123,8 +123,7 @@ test.describe("admin connected", function () {
     });
   });
 
-  // TODO: add the checks after form submission completion
-  test("create NEAR transfer payment request and should clear form after submission", async ({
+  test("create NEAR transfer payment request, and after submission it should be visible in pending request, and the form should be cleared", async ({
     page,
     instanceAccount,
     daoAccount,
@@ -257,7 +256,7 @@ test.describe("admin connected", function () {
           } else {
             retryCountAfterComplete++;
           }
-          console.log(JSON.stringify(result));
+
           json.result.result = Array.from(
             new TextEncoder().encode(JSON.stringify(result))
           );
@@ -296,7 +295,7 @@ test.describe("admin connected", function () {
             votes: {},
             submission_time: "1729004234137594481",
           });
-          console.log(JSON.stringify(result));
+
           json.result.result = Array.from(
             new TextEncoder().encode(JSON.stringify(result))
           );


### PR DESCRIPTION
Add to the "create NEAR payment request" test so that it checks that:

- the request appears in the pending requests list after submission
- after the submission, the payment request form is cleared when clicking create payment request
- the payment request is still cleared if reloading the page and clicking "create request"

Below are video recordings of test runs

https://github.com/user-attachments/assets/986bc20e-326f-481c-8e99-8212c7285846


https://github.com/user-attachments/assets/01f39a3b-fe0b-4da7-8a9c-82f226f31b6c


fixes #78 