### PR TITLE
Add form validation to the amount field and test

### DIFF
--- a/instances/treasury-devdao.near/widget/pages/payments/CreatePaymentRequest.jsx
+++ b/instances/treasury-devdao.near/widget/pages/payments/CreatePaymentRequest.jsx
@@ -354,6 +354,21 @@ function isAccountValid() {
   );
 }
 
+function isAmountValid() {
+  const maxU128 = Big("340282366920938463463374607431768211455");
+
+  // Check if amount is not too big
+  if (Big(parsedAmount).gt(maxU128)) {
+    return false;
+  }
+
+  // Check if amount is not negative or zero
+  if (Big(parsedAmount).lte(0)) {
+    return false;
+  }
+  return true;
+}
+
 useEffect(() => {
   if (
     tokenId &&
@@ -588,7 +603,8 @@ return (
               !receiver ||
               !selectedProposal?.name ||
               !tokenId ||
-              !isAccountValid(),
+              !isAccountValid() ||
+              !isAmountValid(),
             label: "Submit",
             onClick: onSubmitClick,
             loading: isTxnCreated,

--- a/playwright-tests/tests/payments/create-payment-request.spec.js
+++ b/playwright-tests/tests/payments/create-payment-request.spec.js
@@ -179,7 +179,21 @@ test.describe("admin connected", function () {
     await checkForErrorWithAmountField(page, "=-34232[]/", false);
   });
 
-  test("should throw pikespeak error when reponse is 403", async ({
+  test("should disable submit button on negative amount or numbers", async ({
+    page,
+    instanceAccount,
+    daoAccount,
+  }) => {
+    test.setTimeout(60_000);
+    await mockPikespeakFTTokensResponse({ page, daoAccount });
+    await updateDaoPolicyMembers({ page });
+    await fillCreateForm(page, daoAccount, instanceAccount);
+
+    await checkForErrorWithAmountField(page, "-34232", true);
+    await checkForErrorWithAmountField(page, "1111111111111111", true);
+  });
+
+  test("should throw pikespeak error when response is 403", async ({
     page,
     instanceAccount,
   }) => {
@@ -202,7 +216,7 @@ test.describe("admin connected", function () {
     await updateDaoPolicyMembers({ page });
     await page.goto(`/${instanceAccount}/widget/app?page=payments`);
     await clickCreatePaymentRequestButton(page);
-    const tokenSelect = await page.getByTestId("tokens-dropdown");
+    const tokenSelect = page.getByTestId("tokens-dropdown");
     await tokenSelect.click();
     await tokenSelect.getByText("NEAR").click();
     await tokenSelect.click();


### PR DESCRIPTION
I noticed that 
- a user was still able to submit negative and huge numbers that would result in a smart contract panic. 
- as user could create a payment request with 0 as amount

So I added a small function checking this and wrote a test for it

<img width="504" alt="Screenshot 2024-10-18 at 12 13 21" src="https://github.com/user-attachments/assets/33f83ef4-e813-4a3f-b7a6-c0487da071e7">

![invalid digit](https://github.com/user-attachments/assets/5e85ff29-3995-46de-9d19-2a1b32c9baf5)


[video.webm](https://github.com/user-attachments/assets/e45d592e-f40c-4d08-905a-8547a35c98f8)
