### PR TITLE
tests: cancel payment request, submit button disabled

### DIFF
--- a/playwright-tests/tests/payments/create-payment-request.spec.js
+++ b/playwright-tests/tests/payments/create-payment-request.spec.js
@@ -13,6 +13,7 @@ import {
 } from "../../util/inventory.js";
 import os from "os";
 import { mockPikespeakFTTokensResponse } from "../../util/pikespeak.js";
+import { mockNearPrice } from "../../util/nearblocks.js";
 
 async function clickCreatePaymentRequestButton(page) {
   const createPaymentRequestButton = await page.getByRole("button", {
@@ -199,7 +200,6 @@ test.describe("admin connected", function () {
     instanceAccount,
     daoAccount,
   }) => {
-    test.setTimeout(120_000);
     await mockPikespeakFTTokensResponse({ page, daoAccount });
     await updateDaoPolicyMembers({ page });
     await fillCreateForm(page, daoAccount, instanceAccount);
@@ -213,9 +213,67 @@ test.describe("admin connected", function () {
 
     await clickCreatePaymentRequestButton(page);
 
-    // TODO: add a case where the form is a proposal selection instead of a manual title and summary
     expect(await page.getByTestId("proposal-title").inputValue()).toBe("");
     expect(await page.getByTestId("proposal-summary").inputValue()).toBe("");
+    expect(await page.getByPlaceholder("treasury.near").inputValue()).toBe("");
+    expect(await page.getByTestId("total-amount").inputValue()).toBe("");
+  });
+
+  test("cancel form with linked proposal should clear existing values", async ({
+    page,
+    instanceAccount,
+    daoAccount,
+  }) => {
+    const nearPrice = 4;
+    const amountFromLinkedProposal = 3120 / nearPrice;
+
+    await mockNearPrice({ nearPrice, page });
+    await mockInventory({ page, account: daoAccount });
+    const instanceConfig = await getInstanceConfig({ page, instanceAccount });
+    if (instanceConfig.showProposalSelection === false) {
+      console.log(
+        "Skip testing linked proposal, since instance does not support proposal selection"
+      );
+      return;
+    }
+
+    await mockPikespeakFTTokensResponse({ page, daoAccount });
+    await updateDaoPolicyMembers({ page });
+
+    await page.goto(`/${instanceAccount}/widget/app?page=payments`);
+    await clickCreatePaymentRequestButton(page);
+
+    const proposalSelect = page.locator(".dropdown-toggle").first();
+    await expect(proposalSelect).toBeVisible();
+
+    await expect(
+      proposalSelect.getByText("Select", { exact: true })
+    ).toBeVisible();
+
+    await proposalSelect.click();
+    const proposal = page.getByText("#173 Near Contract Standards");
+    await proposal.click();
+    expect(await page.getByPlaceholder("treasury.near").inputValue()).toBe(
+      "robert.near"
+    );
+
+    expect(await page.getByTestId("total-amount").inputValue()).toBe(
+      amountFromLinkedProposal.toString()
+    );
+
+    const cancelBtn = page
+      .locator(".offcanvas-body")
+      .locator("button.btn-outline", { hasText: "Cancel" });
+    await expect(cancelBtn).toBeAttached({ timeout: 10_000 });
+
+    cancelBtn.click();
+    await page.locator("button", { hasText: "Yes" }).click();
+
+    await clickCreatePaymentRequestButton(page);
+
+    await expect(await page.locator(".dropdown-toggle").first()).toHaveText(
+      "Select"
+    );
     expect(await page.getByPlaceholder("treasury.near").inputValue()).toBe("");
     expect(await page.getByTestId("total-amount").inputValue()).toBe("");
   });
@@ -356,21 +414,7 @@ test.describe("admin with function access keys", function () {
     const nearPrice = 4;
     await mockInventory({ page, account: daoAccount });
     const instanceConfig = await getInstanceConfig({ page, instanceAccount });
-    await page.route(
-      "https://api3.nearblocks.io/v1/charts/latest",
-      async (route) => {
-        let json = {
-          charts: [
-            {
-              date: "2024-10-12T00:00:00.000Z",
-              near_price: nearPrice.toString(),
-              txns: "6113720",
-            },
-          ],
-        };
-        await route.fulfill({ json });
-      }
-    );
+    await mockNearPrice({ nearPrice, page });
     await mockPikespeakFTTokensResponse({ page, daoAccount });
     await updateDaoPolicyMembers({ page });
     await page.goto(`/${instanceAccount}/widget/app?page=payments`);

--- a/playwright-tests/util/forms.js
+++ b/playwright-tests/util/forms.js
@@ -1,0 +1,31 @@
+/**
+ * Focuses on an input field, selects all text, clears it, and then removes focus.
+ * @param {Object} params - The parameters for the function.
+ * @param {import('playwright').ElementHandle} params.inputField - The Playwright ElementHandle for the input field.
+ * @returns {Promise<void>} A promise that resolves once the input field is focused, cleared, and blurred.
+ */
+export async function focusInputClearAndBlur({ inputField }) {
+  await inputField.focus();
+  await inputField.press(
+    process.platform === "darwin" ? "Meta+A" : "Control+A"
+  );
+  await inputField.press("Delete");
+  await inputField.blur();
+}
+
+/**
+ * Focuses on an input field, selects all text, clears it, replaces it with a specified value, and then removes focus.
+ * @param {Object} params - The parameters for the function.
+ * @param {import('playwright').ElementHandle} params.inputField - The Playwright ElementHandle for the input field.
+ * @param {string} params.newValue - The new value to set in the input field.
+ * @returns {Promise<void>} A promise that resolves once the input field is focused, cleared, updated, and blurred.
+ */
+export async function focusInputReplaceAndBlur({ inputField, newValue }) {
+  await inputField.focus();
+  await inputField.press(
+    process.platform === "darwin" ? "Meta+A" : "Control+A"
+  );
+  await inputField.press("Delete");
+  await inputField.type(newValue); // Types the specified value into the input field
+  await inputField.blur();
+}

--- a/playwright-tests/util/nearblocks.js
+++ b/playwright-tests/util/nearblocks.js
@@ -1,0 +1,24 @@
+/**
+ * Mocks the NEAR price on a given page.
+ * @param {Object} params - The parameters for the function.
+ * @param {number} params.nearPrice - The NEAR price as a floating-point number.
+ * @param {import('playwright').Page} params.page - The Playwright Page instance.
+ * @returns {Promise<void>} A promise that resolves when the mock is complete.
+ */
+export async function mockNearPrice({ nearPrice, page }) {
+  await page.route(
+    "https://api3.nearblocks.io/v1/charts/latest",
+    async (route) => {
+      let json = {
+        charts: [
+          {
+            date: "2024-10-12T00:00:00.000Z",
+            near_price: nearPrice.toString(),
+            txns: "6113720",
+          },
+        ],
+      };
+      await route.fulfill({ json });
+    }
+  );
+}


### PR DESCRIPTION
add two of the remaining test cases after the QA effort in #63 

- cancel payment request for a linked proposal 

https://github.com/user-attachments/assets/17100b01-06c4-4d09-8edb-68b2ac3229ec


- submit should be disabled when incorrect receiver id is mentioned or empty amount or empty proposal name or empty token

https://github.com/user-attachments/assets/ec704010-0697-4b5b-9770-af294cf030ba

- also added util methods `focusInputClearAndBlur` and `focusInputReplaceAndBlur` for simulation of clearing and input and filling in a new value
- added util method for mocking the NEAR price


fixes #94 
fixes #95 

