### PR TITLE
Fix unstable tests

### DIFF
--- a/playwright-tests/tests/members/create-threshold-request.spec.js
+++ b/playwright-tests/tests/members/create-threshold-request.spec.js
@@ -42,6 +42,11 @@ async function checkForVoteApproveTxn(page) {
   });
 }
 
+test.afterEach(async ({ page }, testInfo) => {
+  console.log(`Finished ${testInfo.title} with status ${testInfo.status}`);
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+});
+
 test.describe("without login", function () {
   test.beforeEach(async ({ page, instanceAccount }) => {
     const instanceConfig = await getInstanceConfig({ page, instanceAccount });

--- a/playwright-tests/tests/payments/requests-feed.spec.js
+++ b/playwright-tests/tests/payments/requests-feed.spec.js
@@ -7,6 +7,11 @@ import {
   TransferProposalData,
 } from "../../util/inventory.js";
 
+test.afterEach(async ({ page }, testInfo) => {
+  console.log(`Finished ${testInfo.title} with status ${testInfo.status}`);
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+});
+
 test.describe("payment requests feed", function () {
   test("expect expired request to be in history", async ({
     page,

--- a/playwright-tests/tests/stake-delegation/stake-delegation.spec.js
+++ b/playwright-tests/tests/stake-delegation/stake-delegation.spec.js
@@ -19,7 +19,7 @@ test.describe("admin connected", function () {
     instanceAccount,
     daoAccount,
   }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(30_000);
     const instanceConfig = await getInstanceConfig({ page, instanceAccount });
     if (
       !instanceConfig.navbarLinks.find(
@@ -37,9 +37,12 @@ test.describe("admin connected", function () {
     const createRequestButton = await page.getByText("Create Request");
     await createRequestButton.click();
     await page.waitForTimeout(1000);
-    const firstStakingPoolSelect = await page
-      .locator("button", { hasText: "select" })
-      .first();
+    const selectButtons = await page.locator("button", { hasText: "select" });
+    while (selectButtons.count() < 2 || !selectButtons.first().isEnabled()) {
+      await page.waitForTimeout(100);
+    }
+
+    const firstStakingPoolSelect = await selectButtons.first();
 
     await firstStakingPoolSelect.click();
     const stakingPoolAccount = await page

--- a/playwright-tests/tests/stake-delegation/stake-delegation.spec.js
+++ b/playwright-tests/tests/stake-delegation/stake-delegation.spec.js
@@ -19,7 +19,7 @@ test.describe("admin connected", function () {
     instanceAccount,
     daoAccount,
   }) => {
-    test.setTimeout(30_000);
+    test.setTimeout(40_000);
     const instanceConfig = await getInstanceConfig({ page, instanceAccount });
     if (
       !instanceConfig.navbarLinks.find(


### PR DESCRIPTION
- Fix "test ended" error by adding page.unrouteAll to the tests that didn't have it
- Make staking delegation test more stable by waiting for staking select buttons to appear and be enabled.