### PR TITLE
show modal with impacted proposals when changing voting duration

### DIFF
--- a/instances/treasury-devdao.near/widget/lib/modal.jsx
+++ b/instances/treasury-devdao.near/widget/lib/modal.jsx
@@ -46,6 +46,7 @@ const ModalDialog = styled.div`
   max-height: 85%;
   margin-top: 5%;
   width: 35%;
+  border-radius: 20px;
 
   @media screen and (max-width: 768px) {
     margin: 2rem;

--- a/instances/treasury-devdao.near/widget/lib/modal.jsx
+++ b/instances/treasury-devdao.near/widget/lib/modal.jsx
@@ -1,0 +1,108 @@
+const Modal = styled.div`
+  display: ${({ hidden }) => (hidden ? "none" : "flex")};
+  position: fixed;
+  inset: 0;
+  justify-content: center;
+  align-items: center;
+  opacity: 1;
+  z-index: 999;
+
+  .black-btn {
+    background-color: #000 !important;
+    border: none;
+    color: white;
+    &:active {
+      color: white;
+    }
+  }
+
+  @media screen and (max-width: 768px) {
+    h5 {
+      font-size: 16px !important;
+    }
+  }
+
+  .btn {
+    font-size: 14px;
+  }
+
+  .theme-btn {
+    background: var(--theme-color) !important;
+    color: white;
+  }
+`;
+
+const ModalBackdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  opacity: 0.4;
+`;
+
+const ModalDialog = styled.div`
+  padding: 2em;
+  z-index: 999;
+  overflow-y: auto;
+  max-height: 85%;
+  margin-top: 5%;
+  width: 35%;
+
+  @media screen and (max-width: 768px) {
+    margin: 2rem;
+    width: 100%;
+  }
+`;
+
+const ModalHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 4px;
+`;
+
+const ModalFooter = styled.div`
+  padding-top: 4px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: items-center;
+`;
+
+const CloseButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: white;
+  padding: 0.5em;
+  border-radius: 6px;
+  border: 0;
+  color: #344054;
+
+  &:hover {
+    background-color: #d3d3d3;
+  }
+`;
+
+const ModalContent = styled.div`
+  flex: 1;
+  font-size: 14px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  overflow-y: auto;
+  max-height: 50%;
+  text-align: left !important;
+  @media screen and (max-width: 768px) {
+    font-size: 12px !important;
+  }
+`;
+
+const NoButton = styled.button`
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+`;
+
+return { Modal, ModalBackdrop, ModalContent, ModalDialog, ModalHeader };

--- a/instances/treasury-devdao.near/widget/pages/settings/VotingDurationPage.jsx
+++ b/instances/treasury-devdao.near/widget/pages/settings/VotingDurationPage.jsx
@@ -139,7 +139,7 @@ const findAffectedProposals = (callback) => {
       newOtherPendingRequests
     ) => {
       Near.asyncView(treasuryDaoID, "get_proposals", {
-        from_index: lastIndex - limit,
+        from_index: lastIndex < limit ? 0 : lastIndex - limit,
         limit,
       }).then((/** @type Array */ proposals) => {
         const now = new Date().getTime();
@@ -175,7 +175,7 @@ const findAffectedProposals = (callback) => {
               ...proposal,
             });
           }
-          fetchMore = currentExpiryTime >= now;
+          fetchMore = proposals.length === limit && currentExpiryTime >= now;
         }
         setProposalsThatWillExpire(newProposalsThatWillExpire);
         setOtherPendingRequests(newOtherPendingRequests);
@@ -201,7 +201,7 @@ const findAffectedProposals = (callback) => {
       newOtherPendingRequests
     ) => {
       Near.asyncView(treasuryDaoID, "get_proposals", {
-        from_index: lastIndex - limit,
+        from_index: lastIndex < limit ? 0 : lastIndex - limit,
         limit,
       }).then((/** @type Array */ proposals) => {
         const now = new Date().getTime();
@@ -237,7 +237,7 @@ const findAffectedProposals = (callback) => {
               ...proposal,
             });
           }
-          fetchMore = newExpiryTime >= now;
+          fetchMore = proposals.length === limit && newExpiryTime >= now;
         }
         setProposalsThatWillBeActive(newProposalsThatWillBeActive);
         setOtherPendingRequests(newOtherPendingRequests);
@@ -312,6 +312,9 @@ useEffect(() => {
 const changeDurationDays = (newDurationDays) => {
   setDurationDays(newDurationDays);
 };
+
+const showImpactedRequests =
+  proposalsThatWillExpire.length > 0 || proposalsThatWillBeActive.length > 0;
 
 return (
   <Container>
@@ -395,63 +398,67 @@ return (
                   ) : (
                     ""
                   )}
-                  <li>Impacted requests:</li>
+                  {showImpactedRequests ? <li>Impacted requests:</li> : ""}
                 </ul>
-                <table className="table table-sm">
-                  <thead>
-                    <tr className="text-grey">
-                      <th>Id</th>
-                      <th>Description</th>
-                      <th>Submission date</th>
-                      <th>Current expiry</th>
-                      <th>New expiry</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {proposalsThatWillExpire.map((proposal) => (
-                      <tr class="proposal-that-will-expire">
-                        <td>{proposal.id}</td>
-                        <td>{proposal.description}</td>
-                        <td>
-                          {new Date(proposal.submissionTimeMillis)
-                            .toJSON()
-                            .substring(0, "yyyy-mm-dd".length)}
-                        </td>
-                        <td>
-                          {new Date(proposal.currentExpiryTime)
-                            .toJSON()
-                            .substring(0, "yyyy-mm-dd".length)}
-                        </td>
-                        <td>
-                          {new Date(proposal.newExpiryTime)
-                            .toJSON()
-                            .substring(0, "yyyy-mm-dd".length)}
-                        </td>
+                {showImpactedRequests ? (
+                  <table className="table table-sm">
+                    <thead>
+                      <tr className="text-grey">
+                        <th>Id</th>
+                        <th>Description</th>
+                        <th>Submission date</th>
+                        <th>Current expiry</th>
+                        <th>New expiry</th>
                       </tr>
-                    ))}
-                    {proposalsThatWillBeActive.map((proposal) => (
-                      <tr class="proposal-that-will-be-active">
-                        <td>{proposal.id}</td>
-                        <td>{proposal.description}</td>
-                        <td>
-                          {new Date(proposal.submissionTimeMillis)
-                            .toJSON()
-                            .substring(0, "yyyy-mm-dd".length)}
-                        </td>
-                        <td>
-                          {new Date(proposal.currentExpiryTime)
-                            .toJSON()
-                            .substring(0, "yyyy-mm-dd".length)}
-                        </td>
-                        <td>
-                          {new Date(proposal.newExpiryTime)
-                            .toJSON()
-                            .substring(0, "yyyy-mm-dd".length)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody>
+                      {proposalsThatWillExpire.map((proposal) => (
+                        <tr class="proposal-that-will-expire">
+                          <td>{proposal.id}</td>
+                          <td>{proposal.description}</td>
+                          <td>
+                            {new Date(proposal.submissionTimeMillis)
+                              .toJSON()
+                              .substring(0, "yyyy-mm-dd".length)}
+                          </td>
+                          <td>
+                            {new Date(proposal.currentExpiryTime)
+                              .toJSON()
+                              .substring(0, "yyyy-mm-dd".length)}
+                          </td>
+                          <td>
+                            {new Date(proposal.newExpiryTime)
+                              .toJSON()
+                              .substring(0, "yyyy-mm-dd".length)}
+                          </td>
+                        </tr>
+                      ))}
+                      {proposalsThatWillBeActive.map((proposal) => (
+                        <tr class="proposal-that-will-be-active">
+                          <td>{proposal.id}</td>
+                          <td>{proposal.description}</td>
+                          <td>
+                            {new Date(proposal.submissionTimeMillis)
+                              .toJSON()
+                              .substring(0, "yyyy-mm-dd".length)}
+                          </td>
+                          <td>
+                            {new Date(proposal.currentExpiryTime)
+                              .toJSON()
+                              .substring(0, "yyyy-mm-dd".length)}
+                          </td>
+                          <td>
+                            {new Date(proposal.newExpiryTime)
+                              .toJSON()
+                              .substring(0, "yyyy-mm-dd".length)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                ) : (
+                  ""
+                )}
                 {proposalsThatWillBeActive.length > 0 ? (
                   <p>
                     If you do not want expired proposals to be open for voting

--- a/instances/treasury-devdao.near/widget/pages/settings/VotingDurationPage.jsx
+++ b/instances/treasury-devdao.near/widget/pages/settings/VotingDurationPage.jsx
@@ -348,8 +348,8 @@ return (
             <ModalDialog className="card">
               <ModalHeader>
                 <h5 className="mb-0">
-                  Changing the voting duration will affect the status of some
-                  requests
+                  <i class="bi bi-exclamation-triangle text-warning"></i>
+                  Impact of changing voting duration
                 </h5>
               </ModalHeader>
               <ModalContent>
@@ -360,8 +360,6 @@ return (
                 <ul>
                   {otherPendingRequests.length > 0 ? (
                     <li>
-                      Pending requests:
-                      <br />
                       <b>{otherPendingRequests.length} pending requests</b> will
                       now follow the new voting duration policy.
                     </li>
@@ -370,11 +368,7 @@ return (
                   )}
                   {proposalsThatWillExpire.length > 0 ? (
                     <li>
-                      Active requests:
-                      <br />
-                      <b>
-                        {proposalsThatWillExpire.length} active requests
-                      </b>{" "}
+                      <b>{proposalsThatWillExpire.length} active requests</b>{" "}
                       under the old voting duration will move to the "Archived"
                       tab and close for voting. These requests were created
                       outside the new voting period and are no longer considered
@@ -385,11 +379,7 @@ return (
                   )}
                   {proposalsThatWillBeActive.length > 0 ? (
                     <li>
-                      Expired requests:
-                      <br />
-                      <b>
-                        {proposalsThatWillBeActive.length} expired requests
-                      </b>{" "}
+                      <b>{proposalsThatWillBeActive.length} expired requests</b>{" "}
                       under the old voting duration will move back to the
                       "Pending Requests" tab and reopen for voting. These
                       requests were created within the new voting period and are
@@ -398,64 +388,66 @@ return (
                   ) : (
                     ""
                   )}
-                  {showImpactedRequests ? <li>Impacted requests:</li> : ""}
                 </ul>
                 {showImpactedRequests ? (
-                  <table className="table table-sm">
-                    <thead>
-                      <tr className="text-grey">
-                        <th>Id</th>
-                        <th>Description</th>
-                        <th>Submission date</th>
-                        <th>Current expiry</th>
-                        <th>New expiry</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {proposalsThatWillExpire.map((proposal) => (
-                        <tr class="proposal-that-will-expire">
-                          <td>{proposal.id}</td>
-                          <td>{proposal.description}</td>
-                          <td>
-                            {new Date(proposal.submissionTimeMillis)
-                              .toJSON()
-                              .substring(0, "yyyy-mm-dd".length)}
-                          </td>
-                          <td>
-                            {new Date(proposal.currentExpiryTime)
-                              .toJSON()
-                              .substring(0, "yyyy-mm-dd".length)}
-                          </td>
-                          <td>
-                            {new Date(proposal.newExpiryTime)
-                              .toJSON()
-                              .substring(0, "yyyy-mm-dd".length)}
-                          </td>
+                  <>
+                    <h4>Summary of changes</h4>
+                    <table className="table table-sm">
+                      <thead>
+                        <tr className="text-grey">
+                          <th>Id</th>
+                          <th>Description</th>
+                          <th>Submission date</th>
+                          <th>Current expiry</th>
+                          <th>New expiry</th>
                         </tr>
-                      ))}
-                      {proposalsThatWillBeActive.map((proposal) => (
-                        <tr class="proposal-that-will-be-active">
-                          <td>{proposal.id}</td>
-                          <td>{proposal.description}</td>
-                          <td>
-                            {new Date(proposal.submissionTimeMillis)
-                              .toJSON()
-                              .substring(0, "yyyy-mm-dd".length)}
-                          </td>
-                          <td>
-                            {new Date(proposal.currentExpiryTime)
-                              .toJSON()
-                              .substring(0, "yyyy-mm-dd".length)}
-                          </td>
-                          <td>
-                            {new Date(proposal.newExpiryTime)
-                              .toJSON()
-                              .substring(0, "yyyy-mm-dd".length)}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                      </thead>
+                      <tbody>
+                        {proposalsThatWillExpire.map((proposal) => (
+                          <tr class="proposal-that-will-expire">
+                            <td>{proposal.id}</td>
+                            <td>{proposal.description}</td>
+                            <td>
+                              {new Date(proposal.submissionTimeMillis)
+                                .toJSON()
+                                .substring(0, "yyyy-mm-dd".length)}
+                            </td>
+                            <td>
+                              {new Date(proposal.currentExpiryTime)
+                                .toJSON()
+                                .substring(0, "yyyy-mm-dd".length)}
+                            </td>
+                            <td>
+                              {new Date(proposal.newExpiryTime)
+                                .toJSON()
+                                .substring(0, "yyyy-mm-dd".length)}
+                            </td>
+                          </tr>
+                        ))}
+                        {proposalsThatWillBeActive.map((proposal) => (
+                          <tr class="proposal-that-will-be-active">
+                            <td>{proposal.id}</td>
+                            <td>{proposal.description}</td>
+                            <td>
+                              {new Date(proposal.submissionTimeMillis)
+                                .toJSON()
+                                .substring(0, "yyyy-mm-dd".length)}
+                            </td>
+                            <td>
+                              {new Date(proposal.currentExpiryTime)
+                                .toJSON()
+                                .substring(0, "yyyy-mm-dd".length)}
+                            </td>
+                            <td>
+                              {new Date(proposal.newExpiryTime)
+                                .toJSON()
+                                .substring(0, "yyyy-mm-dd".length)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </>
                 ) : (
                   ""
                 )}

--- a/instances/treasury-devdao.near/widget/pages/settings/VotingDurationPage.jsx
+++ b/instances/treasury-devdao.near/widget/pages/settings/VotingDurationPage.jsx
@@ -328,6 +328,19 @@ return (
                   You are about to update the voting duration. This will affect
                   the following existing requests.
                 </p>
+                <ul>
+                {proposalsThatWillExpire.length > 0 ? <li>
+                  <b>{proposalsThatWillExpire.length} active requests</b> under the old voting duration
+                  will move to the "Archived" tab and close for voting. These requests were
+                  created outside the new voting period and are no longer considered active. 
+                </li>: ""}
+                {proposalsThatWillBeActive.length > 0 ? <li>
+                  <b>{proposalsThatWillBeActive.length} expired requests</b> under the old voting duration
+                  will move back to the "Pending Requests" tab and reopen for voting. These requests were
+                  created within the new voting period and are no longer considered expired. 
+                </li>: ""}
+                <li>Impacted requests:</li>
+                </ul>
                 <table className="table table-sm">
                   <thead>
                     <tr className="text-grey">
@@ -383,6 +396,9 @@ return (
                     ))}
                   </tbody>
                 </table>
+                {proposalsThatWillBeActive.length > 0 ? <p>
+                  If you do not want expired proposals to be open for voting again, you may need to delete them.
+                </p> : ""}
               </ModalContent>
               <div className="modalfooter d-flex gap-2 align-items-center justify-content-end mt-2">
                 <Widget

--- a/instances/treasury-devdao.near/widget/pages/settings/VotingDurationPage.jsx
+++ b/instances/treasury-devdao.near/widget/pages/settings/VotingDurationPage.jsx
@@ -329,17 +329,29 @@ return (
                   the following existing requests.
                 </p>
                 <ul>
-                {proposalsThatWillExpire.length > 0 ? <li>
-                  <b>{proposalsThatWillExpire.length} active requests</b> under the old voting duration
-                  will move to the "Archived" tab and close for voting. These requests were
-                  created outside the new voting period and are no longer considered active. 
-                </li>: ""}
-                {proposalsThatWillBeActive.length > 0 ? <li>
-                  <b>{proposalsThatWillBeActive.length} expired requests</b> under the old voting duration
-                  will move back to the "Pending Requests" tab and reopen for voting. These requests were
-                  created within the new voting period and are no longer considered expired. 
-                </li>: ""}
-                <li>Impacted requests:</li>
+                  {proposalsThatWillExpire.length > 0 ? (
+                    <li>
+                      <b>{proposalsThatWillExpire.length} active requests</b>{" "}
+                      under the old voting duration will move to the "Archived"
+                      tab and close for voting. These requests were created
+                      outside the new voting period and are no longer considered
+                      active.
+                    </li>
+                  ) : (
+                    ""
+                  )}
+                  {proposalsThatWillBeActive.length > 0 ? (
+                    <li>
+                      <b>{proposalsThatWillBeActive.length} expired requests</b>{" "}
+                      under the old voting duration will move back to the
+                      "Pending Requests" tab and reopen for voting. These
+                      requests were created within the new voting period and are
+                      no longer considered expired.
+                    </li>
+                  ) : (
+                    ""
+                  )}
+                  <li>Impacted requests:</li>
                 </ul>
                 <table className="table table-sm">
                   <thead>
@@ -396,9 +408,14 @@ return (
                     ))}
                   </tbody>
                 </table>
-                {proposalsThatWillBeActive.length > 0 ? <p>
-                  If you do not want expired proposals to be open for voting again, you may need to delete them.
-                </p> : ""}
+                {proposalsThatWillBeActive.length > 0 ? (
+                  <p>
+                    If you do not want expired proposals to be open for voting
+                    again, you may need to delete them.
+                  </p>
+                ) : (
+                  ""
+                )}
               </ModalContent>
               <div className="modalfooter d-flex gap-2 align-items-center justify-content-end mt-2">
                 <Widget

--- a/playwright-tests/tests/settings/voting-duration.spec.js
+++ b/playwright-tests/tests/settings/voting-duration.spec.js
@@ -65,6 +65,10 @@ test.describe("admin connected", function () {
     await page.waitForTimeout(500);
     await page.locator("button", { hasText: "Submit" }).click();
 
+    await page
+      .locator(".modalfooter button", { hasText: "Yes, proceed" })
+      .click();
+
     await expect(await getTransactionModalObject(page)).toEqual({
       proposal: {
         description: "Change proposal period",
@@ -126,6 +130,7 @@ test.describe("admin connected", function () {
     instanceAccount,
     daoAccount,
   }) => {
+    test.setTimeout(60_000);
     const daoName = daoAccount.split(".")[0];
 
     const sandbox = new SandboxRPC();
@@ -165,6 +170,10 @@ test.describe("admin connected", function () {
 
     await page.waitForTimeout(500);
     await page.locator("button", { hasText: "Submit" }).click();
+
+    await page
+      .locator(".modalfooter button", { hasText: "Yes, proceed" })
+      .click();
 
     const transactionToSendPromise = page.evaluate(async () => {
       const selector = await document.querySelector("near-social-viewer")

--- a/playwright-tests/tests/settings/voting-duration.spec.js
+++ b/playwright-tests/tests/settings/voting-duration.spec.js
@@ -354,18 +354,18 @@ test.describe("admin connected", function () {
         if (expectedUnaffectedActiveProposals.length > 0) {
           await expect(
             page.getByText(
-              `Pending requests: ${expectedUnaffectedActiveProposals.length} pending`
+              `${expectedUnaffectedActiveProposals.length} pending requests`
             )
           ).toBeVisible();
         }
         if (expectedNewExpiredProposals.length > 0) {
           await expect(
             await page.getByText(
-              `Active requests: ${expectedNewExpiredProposals.length} active`
+              `${expectedNewExpiredProposals.length} active requests`
             )
           ).toBeVisible();
           await expect(
-            page.getByRole("heading", { name: "Changing the voting duration" })
+            page.getByRole("heading", { name: "Impact of changing voting duration" })
           ).toBeVisible();
           await expect(
             await page.locator(".proposal-that-will-expire")
@@ -382,16 +382,16 @@ test.describe("admin connected", function () {
             .locator(".modalfooter button", { hasText: "Cancel" })
             .click();
           await expect(
-            page.getByRole("heading", { name: "Changing the voting duration" })
+            page.getByRole("heading", { name: "Impact of changing voting duration" })
           ).not.toBeVisible();
         } else if (expectedNewActiveProposals.length > 0) {
           await expect(
             await page.getByText(
-              `Expired requests: ${expectedNewActiveProposals.length} expired`
+              `${expectedNewActiveProposals.length} expired`
             )
           ).toBeVisible();
           await expect(
-            page.getByRole("heading", { name: "Changing the voting duration" })
+            page.getByRole("heading", { name: "Impact of changing voting duration" })
           ).toBeVisible();
           await expect(
             await page.locator(".proposal-that-will-be-active")
@@ -406,7 +406,7 @@ test.describe("admin connected", function () {
             .locator(".modalfooter button", { hasText: "Cancel" })
             .click();
           await expect(
-            page.getByRole("heading", { name: "Changing the voting duration" })
+            page.getByRole("heading", { name: "Impact of changing voting duration" })
           ).not.toBeVisible();
         } else {
           await expect(

--- a/playwright-tests/tests/settings/voting-duration.spec.js
+++ b/playwright-tests/tests/settings/voting-duration.spec.js
@@ -284,7 +284,13 @@ test.describe("admin connected", function () {
         .getByPlaceholder("Enter voting duration days")
         .fill(newDurationDays.toString());
 
+      await page.waitForTimeout(300);
+      await page.getByRole("button", { name: "Submit Request" }).click();
+
       const checkExpectedNewExpiredProposals = async () => {
+        await expect(
+          page.getByRole("heading", { name: "Changing the voting duration" })
+        ).toBeVisible();
         const expectedNewExpiredProposals = proposals
           .filter(
             (proposal) =>
@@ -297,10 +303,6 @@ test.describe("admin connected", function () {
               proposal.status === "InProgress"
           )
           .reverse();
-        await expect(await page.locator(".alert-danger")).toBeVisible();
-        await expect(await page.locator(".alert-danger")).toHaveText(
-          "The following proposals will expire because of the changed duration"
-        );
         await expect(
           await page.locator(".proposal-that-will-expire")
         ).toHaveCount(expectedNewExpiredProposals.length);
@@ -310,6 +312,12 @@ test.describe("admin connected", function () {
         expect(visibleProposalIds).toEqual(
           expectedNewExpiredProposals.map((proposal) => proposal.id.toString())
         );
+        await page
+          .locator(".modalfooter button", { hasText: "Cancel" })
+          .click();
+        await expect(
+          page.getByRole("heading", { name: "Changing the voting duration" })
+        ).not.toBeVisible();
       };
       await checkExpectedNewExpiredProposals();
       await page.waitForTimeout(500);

--- a/playwright-tests/tests/settings/voting-duration.spec.js
+++ b/playwright-tests/tests/settings/voting-duration.spec.js
@@ -365,7 +365,9 @@ test.describe("admin connected", function () {
             )
           ).toBeVisible();
           await expect(
-            page.getByRole("heading", { name: "Impact of changing voting duration" })
+            page.getByRole("heading", {
+              name: "Impact of changing voting duration",
+            })
           ).toBeVisible();
           await expect(
             await page.locator(".proposal-that-will-expire")
@@ -382,16 +384,18 @@ test.describe("admin connected", function () {
             .locator(".modalfooter button", { hasText: "Cancel" })
             .click();
           await expect(
-            page.getByRole("heading", { name: "Impact of changing voting duration" })
+            page.getByRole("heading", {
+              name: "Impact of changing voting duration",
+            })
           ).not.toBeVisible();
         } else if (expectedNewActiveProposals.length > 0) {
           await expect(
-            await page.getByText(
-              `${expectedNewActiveProposals.length} expired`
-            )
+            await page.getByText(`${expectedNewActiveProposals.length} expired`)
           ).toBeVisible();
           await expect(
-            page.getByRole("heading", { name: "Impact of changing voting duration" })
+            page.getByRole("heading", {
+              name: "Impact of changing voting duration",
+            })
           ).toBeVisible();
           await expect(
             await page.locator(".proposal-that-will-be-active")
@@ -406,7 +410,9 @@ test.describe("admin connected", function () {
             .locator(".modalfooter button", { hasText: "Cancel" })
             .click();
           await expect(
-            page.getByRole("heading", { name: "Impact of changing voting duration" })
+            page.getByRole("heading", {
+              name: "Impact of changing voting duration",
+            })
           ).not.toBeVisible();
         } else {
           await expect(


### PR DESCRIPTION


- Removes the current list of affected proposals, that is updated as you type
- Adds a when clicking the "Submit request" button ( and only if there are proposals that will be affected by the voting duration change )
- Shows expired proposals that become active when extending duration days
- Shows pending proposals that will follow the new voting duration ( without expiring or becoming active )

https://github.com/user-attachments/assets/f858e549-b293-4122-9baf-ca3157c32dd3

resolves #145