### PR TITLE
Add editing for members and fix reference_account_id

### DIFF
--- a/instances/treasury-factory.near/aliases.mainnet.json
+++ b/instances/treasury-factory.near/aliases.mainnet.json
@@ -4,6 +4,7 @@
   "REPL_BASE_DEPLOYMENT_ACCOUNT": "treasury-factory.near",
   "REPL_DEVDAO_ACCOUNT": "treasury-devdao.near",
   "REPL_SPUTNIK_FACTORY_ACCOUNT": "sputnik-dao.near",
+  "REPL_FACTORY_REFERENCE_ACCOUNT": "treasury-testing.near",
   "REPL_NEAR": "near",
   "REPL_MOB": "mob.near",
   "REPL_SOCIAL_CONTRACT": "social.near",

--- a/instances/treasury-factory.near/widget/components/NewAccountInput.jsx
+++ b/instances/treasury-factory.near/widget/components/NewAccountInput.jsx
@@ -1,8 +1,16 @@
-const { alertMsg, setAlertMsg, onChange, defaultValue, postfix } = props;
+const {
+  alertMsg,
+  setAlertMsg,
+  onChange,
+  defaultValue,
+  postfix,
+  placeholder,
+  skipValdation,
+} = props;
 
 const [value, setValue] = useState(defaultValue ?? "");
 
-const checkAccountAvailable = async (accountId) => {
+const checkAccountAvailability = async (accountId, postfix) => {
   if (accountId.length === 0) return;
 
   asyncFetch(`${REPL_RPC_URL}`, {
@@ -30,32 +38,48 @@ const checkAccountAvailable = async (accountId) => {
     if (!err) errMsg = `Account ${accountId}${postfix} already been taken`;
     else if (err.name !== "UNKNOWN_ACCOUNT") errMsg = err?.info?.error_message;
 
-    setAlertMsg(errMsg);
+    const newAlertMsg = alertMsg ?? {};
+    newAlertMsg[postfix] = errMsg;
+    setAlertMsg(newAlertMsg);
   });
 };
+
+useEffect(() => {
+  if (!skipValdation) {
+    const handler = setTimeout(() => {
+      checkAccountAvailability(value, ".near");
+      checkAccountAvailability(value, ".sputnik-dao.near");
+    }, 500);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }
+}, [value]);
 
 return (
   <div className="account-field position-relative d-flex align-items-center">
     <input
       type="text"
-      placeholder="app-account"
+      placeholder={placeholder}
       value={value}
       onChange={(e) => {
         const v = e.target.value;
-        checkAccountAvailable(v);
         setValue(v);
         onChange(v);
       }}
     />
-    <div
-      style={{
-        position: "absolute",
-        right: "0px",
-        borderLeft: "1px solid var(--bs-border-color)",
-      }}
-      className="py-2 px-3"
-    >
-      {postfix}
-    </div>
+    {postfix && (
+      <div
+        style={{
+          position: "absolute",
+          right: "0px",
+          borderLeft: "1px solid var(--bs-border-color)",
+        }}
+        className="py-2 px-3"
+      >
+        {postfix}
+      </div>
+    )}
   </div>
 );

--- a/instances/treasury-factory.near/widget/components/create-treasury/AddMembersStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/AddMembersStep.jsx
@@ -64,30 +64,24 @@ const ListItem = ({ member, key }) => (
     </div>
 
     <ActionButtons className="d-flex gap-3 align-items-center justify-content-end w-25">
-      {key > 0 && (
-        <>
-          <i
-            role="button"
-            className="bi bi-pencil"
-            onClick={() => {
-              setFields({
-                accountId: member.accountId,
-                permissions: member.permissions,
-              });
-              setShowAddMemberModal(true);
-            }}
-          />
-          <i
-            role="button"
-            className="bi bi-trash text-danger"
-            onClick={() =>
-              setMembers(
-                members.filter((m) => m.accountId !== member.accountId)
-              )
-            }
-          />
-        </>
-      )}
+      <i
+        role="button"
+        className="bi bi-pencil"
+        onClick={() => {
+          setFields({
+            accountId: member.accountId,
+            permissions: member.permissions,
+          });
+          setShowAddMemberModal(true);
+        }}
+      />
+      <i
+        role="button"
+        className="bi bi-trash text-danger"
+        onClick={() =>
+          setMembers(members.filter((m) => m.accountId !== member.accountId))
+        }
+      />
     </ActionButtons>
   </Item>
 );

--- a/instances/treasury-factory.near/widget/components/create-treasury/ConfirmWalletStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/ConfirmWalletStep.jsx
@@ -3,8 +3,7 @@ const { getNearBalances } = VM.require(
 );
 if (!getNearBalances) return <></>;
 
-const baseUrl = "https://api.pikespeak.ai";
-const REQUIRED_BALANCE = 12;
+const REQUIRED_BALANCE = 9;
 
 let balance = getNearBalances(context.accountId);
 balance = balance ? parseFloat(balance.availableParsed) : 0;
@@ -78,7 +77,7 @@ return (
           />
           <SummaryListItem
             title="Frontend BOS Widget Hosting"
-            value={6}
+            value={3}
             info="Estimated one-time costs to store info in BOS"
           />
           <b>

--- a/instances/treasury-factory.near/widget/components/create-treasury/CreateAppAccountStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/CreateAppAccountStep.jsx
@@ -19,21 +19,21 @@ return (
         alertMsg,
         setAlertMsg,
         defaultValue: formFields.accountName,
-        postfix: ".near",
         onChange: (v) =>
           setFormFields({
             ...formFields,
             accountName: v,
           }),
+        placeholder: "app-account",
       }}
     />
 
-    {alertMsg && (
+    {(alertMsg[".near"] || alertMsg[".sputnik-dao.near"]) && (
       <Widget
         src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.Info`}
         props={{
           type: "alert",
-          text: alertMsg,
+          text: alertMsg[".near"] || alertMsg[".sputnik-dao.near"],
         }}
       />
     )}
@@ -47,7 +47,10 @@ return (
       </Link>
       <Link
         className={`btn btn-primary w-100 ${
-          !alertMsg && formFields.accountName ? "" : "disabled"
+          !(alertMsg[".near"] || alertMsg[".sputnik-dao.near"]) &&
+          formFields.accountName
+            ? ""
+            : "disabled"
         }`}
         href={`/${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/app?page=create-treasury&step=2`}
       >

--- a/instances/treasury-factory.near/widget/components/create-treasury/CreateSputnikAccountStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/CreateSputnikAccountStep.jsx
@@ -13,10 +13,11 @@ if (!formFields.sputnikAccountName)
 return (
   <>
     <div>
-      <h3>Create Sputnik DAO Account</h3>
+      <h3>Add Sputnik DAO Display Name</h3>
       <p>
-        Enter the name for your treasury's Sputnik DAO account. This is where
-        the funds for your treasury will be held.
+        Enter the display name for your treasury's Sputnik DAO account. The
+        funds for your treasury will be held in{" "}
+        <b>{formFields.accountName}.sputnik-dao.near</b>.
       </p>
     </div>
 
@@ -27,12 +28,13 @@ return (
           alertMsg,
           setAlertMsg,
           defaultValue: formFields.sputnikAccountName,
-          postfix: ".sputnik-dao.near",
           onChange: (v) =>
             setFormFields({
               ...formFields,
               sputnikAccountName: v,
             }),
+          skipValdation: true,
+          placeholder: "Display name",
         }}
       />
 

--- a/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
@@ -254,6 +254,7 @@ return (
                   : "-"}
               </div>
             </div>
+
             <Link
               href={`/${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/app?page=create-treasury&step=1`}
             >
@@ -262,13 +263,26 @@ return (
           </div>
         </Section>
 
-        <Section>
+        <Section withBorder>
           <div className="d-flex justify-content-between align-items-center">
             <div>
               <label>Sputnik Account Name</label>
               <div>
+                {formFields.accountName
+                  ? `${formFields.accountName}.sputnik-dao.near`
+                  : "-"}
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        <Section>
+          <div className="d-flex justify-content-between align-items-center">
+            <div>
+              <label>Sputnik Account Display Name</label>
+              <div>
                 {formFields.sputnikAccountName
-                  ? `${formFields.sputnikAccountName}.sputnik-dao.near`
+                  ? `${formFields.sputnikAccountName}`
                   : "-"}
               </div>
             </div>

--- a/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
@@ -1,6 +1,6 @@
 const { formFields } = props;
 
-const REQUIRED_BALANCE = 12;
+const REQUIRED_BALANCE = 9;
 
 const [showCongratsModal, setShowCongratsModal] = useState(false);
 
@@ -167,7 +167,9 @@ function createDao() {
     },
   ]);
 
-  Storage.privateSet("accountName", formFields.accountName);
+  setTimeout(() => {
+    Storage.privateSet("accountName", formFields.accountName);
+  }, 1000);
 }
 
 const CongratsItem = ({ title, link }) => (
@@ -325,7 +327,7 @@ return (
           />
           <SummaryListItem
             title="Frontend BOS Widget Hosting"
-            value={6}
+            value={3}
             info="Estimated one-time costs to store info in BOS"
           />
           <b>

--- a/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
@@ -156,10 +156,10 @@ function createDao() {
       contractName: `${REPL_BASE_DEPLOYMENT_ACCOUNT}`,
       methodName: "create_instance",
       args: {
-        name: `${formFields.sputnikAccountName}`,
+        name: `${formFields.accountName}`,
         sputnik_dao_factory_account_id: `${REPL_SPUTNIK_FACTORY_ACCOUNT}`,
         social_db_account_id: `${REPL_SOCIAL_CONTRACT}`,
-        widget_reference_account_id: `${formFields.accountName}.${REPL_NEAR}`,
+        widget_reference_account_id: `${REPL_FACTORY_REFERENCE_ACCOUNT}`,
         create_dao_args: btoa(JSON.stringify(createDaoConfig)),
       },
       gas: 300000000000000,

--- a/playwright-tests/tests/page.treasury-factory.near.spec.js
+++ b/playwright-tests/tests/page.treasury-factory.near.spec.js
@@ -61,6 +61,10 @@ test.describe("admin connected", function () {
         attachedDeposit: nearApi.utils.format.parseNearAmount("12"),
       });
 
+      expect(
+        transactionToSend.actions[0].params.widget_reference_account_id
+      ).toEqual(widget_reference_account_id);
+
       await page.evaluate((transactionResult) => {
         window.transactionSentPromiseResolve(transactionResult);
       }, transactionResult);


### PR DESCRIPTION
- added ability to edit owner permissions
- fixed `reference_account_id` to be `treasury-testing.near`
- changed 3rd sttep to fill "display name" instead of sputnik-dao account
- added test to verify correctness of `reference_account_id`
- fixed summary information
- reduce attached balance from 12 to 9