### PR TITLE
Update txn confirmation toast with cancel

### DIFF
--- a/instances/treasury-factory.near/widget/components/create-treasury/AddMembersStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/AddMembersStep.jsx
@@ -194,6 +194,7 @@ return (
                   <span>
                     Refer to
                     <a
+                      style={{ color: "#01BF7A" }}
                       className="text-underline"
                       target="_blank"
                       rel="noopener noreferrer"
@@ -220,11 +221,13 @@ return (
         ))}
       </div>
     </div>
-    <div className="d-flex gap-3 info-panel rounded-3 align-items-center">
-      <i class="bi bi-info-circle h6 mb-0"></i>
-      The voting thresholds policy will be set to one vote by default for all
-      permission groups. You can modify those later in the Settings.
-    </div>
+    <Widget
+      src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.Info`}
+      props={{
+        type: "info",
+        text: "The voting thresholds policy will be set to one vote by default for all permission groups. You can modify those later in the Settings.",
+      }}
+    />
     <button
       className="btn btn-outline-plain w-100"
       onClick={() => {

--- a/instances/treasury-factory.near/widget/components/create-treasury/AddMembersStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/AddMembersStep.jsx
@@ -220,7 +220,11 @@ return (
         ))}
       </div>
     </div>
-
+    <div className="d-flex gap-3 info-panel rounded-3 align-items-center">
+      <i class="bi bi-info-circle h6 mb-0"></i>
+      The voting thresholds policy will be set to one vote by default for all
+      permission groups. You can modify those later in the Settings.
+    </div>
     <button
       className="btn btn-outline-plain w-100"
       onClick={() => {

--- a/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
@@ -6,7 +6,6 @@ const { formFields, setShowCongratsModal } = props;
 
 const REQUIRED_BALANCE = 9;
 
-const [showErrorToast, setShowErrorToast] = useState(false);
 const [isTxnCreated, setTxnCreated] = useState(false);
 
 const Section = styled.div`
@@ -67,7 +66,6 @@ const PERMISSIONS = {
 useEffect(() => {
   if (isTxnCreated) {
     let checkTxnTimeout = null;
-    let errorTimeout = null;
 
     const checkAccountCreation = async () => {
       Near.asyncView(`${formFields.accountName}.near`, "web4_get", {
@@ -77,7 +75,6 @@ useEffect(() => {
           if (web4) {
             setTxnCreated(false);
             setShowCongratsModal(true);
-            clearTimeout(errorTimeout);
             clearTimeout(checkTxnTimeout);
             Storage.set("TreasuryAccountName", formFields.accountName);
           } else {
@@ -90,16 +87,8 @@ useEffect(() => {
     };
     checkAccountCreation();
 
-    // if in 40 seconds there is no change, show error condition
-    errorTimeout = setTimeout(() => {
-      setShowErrorToast(true);
-      setTxnCreated(false);
-      clearTimeout(checkTxnTimeout);
-    }, 40_000);
-
     return () => {
       clearTimeout(checkTxnTimeout);
-      clearTimeout(errorTimeout);
     };
   }
 }, [isTxnCreated]);
@@ -267,9 +256,8 @@ const ListItem = ({ member }) => (
 return (
   <>
     <TransactionLoader
-      showInProgress={isTxnCreated}
-      showError={showErrorToast}
-      toggleToast={() => setShowErrorToast(false)}
+      cancelTxn={() => setTxnCreated(false)}
+      showInProgress={true}
     />
     <div className="d-flex flex-column w-100 gap-3">
       <h3>Summary</h3>

--- a/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
@@ -324,11 +324,13 @@ return (
             </div>
           </Section>
         )}
-        <div className="d-flex gap-3 info-panel rounded-3 align-items-center">
-          <i class="bi bi-info-circle h6 mb-0"></i>
-          The voting thresholds policy will be set to one vote by default for
-          all permission groups. You can modify those later in the Settings.
-        </div>
+        <Widget
+          src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.Info`}
+          props={{
+            type: "info",
+            text: "The voting thresholds policy will be set to one vote by default for all permission groups. You can modify those later in the Settings.",
+          }}
+        />
       </Section>
 
       <Section>

--- a/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
+++ b/instances/treasury-factory.near/widget/components/create-treasury/SummaryStep.jsx
@@ -257,11 +257,10 @@ return (
   <>
     <TransactionLoader
       cancelTxn={() => setTxnCreated(false)}
-      showInProgress={true}
+      showInProgress={isTxnCreated}
     />
     <div className="d-flex flex-column w-100 gap-3">
       <h3>Summary</h3>
-
       <div>
         <h4>General</h4>
         <Section withBorder>
@@ -325,6 +324,11 @@ return (
             </div>
           </Section>
         )}
+        <div className="d-flex gap-3 info-panel rounded-3 align-items-center">
+          <i class="bi bi-info-circle h6 mb-0"></i>
+          The voting thresholds policy will be set to one vote by default for
+          all permission groups. You can modify those later in the Settings.
+        </div>
       </Section>
 
       <Section>

--- a/instances/treasury-factory.near/widget/config/css.jsx
+++ b/instances/treasury-factory.near/widget/config/css.jsx
@@ -116,6 +116,15 @@ const ThemeContainer = styled.div`
   .primary-text-color {
     color: var(--theme-color);
   }
+
+ .info-panel {
+  background:  var(--grey-04) !important;
+  color: var(--grey-02)  !important;
+  padding-inline: 0.8rem;
+  padding-block: 0.5rem;
+  font-weight: 500;
+  font-size: 13px;
+ }
 `;
 
 return { ThemeContainer };

--- a/instances/treasury-factory.near/widget/config/css.jsx
+++ b/instances/treasury-factory.near/widget/config/css.jsx
@@ -116,15 +116,6 @@ const ThemeContainer = styled.div`
   .primary-text-color {
     color: var(--theme-color);
   }
-
- .info-panel {
-  background:  var(--grey-04) !important;
-  color: var(--grey-02)  !important;
-  padding-inline: 0.8rem;
-  padding-block: 0.5rem;
-  font-weight: 500;
-  font-size: 13px;
- }
 `;
 
 return { ThemeContainer };

--- a/instances/widgets.treasury-factory.near/widget/components/TokenAmount.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/TokenAmount.jsx
@@ -27,7 +27,7 @@ return (
   <div className="text-center">
     <div className="d-flex gap-1 align-items-center justify-content-end">
       <span className="amount bolder mb-0">
-        {amount.toLocaleString("en-US", {
+        {Number(amount).toLocaleString("en-US", {
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,
         })}

--- a/instances/widgets.treasury-factory.near/widget/components/TransactionLoader.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/TransactionLoader.jsx
@@ -1,36 +1,31 @@
-function TransactionLoader({ showInProgress, showError, toggleToast }) {
-  return showInProgress || showError ? (
+function TransactionLoader({ showInProgress, cancelTxn }) {
+  return showInProgress ? (
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
-      <div className={`toast ${showInProgress || showError ? "show" : ""}`}>
+      <div className={`toast show`}>
         <div class="toast-header px-2">
           <strong class="me-auto">Just Now</strong>
-          {showError && (
-            <i
-              class="bi bi-x-lg h6 mb-0 cursor-pointer"
-              onClick={() => toggleToast(false)}
-            ></i>
-          )}
         </div>
         <div class="toast-body">
-          {showInProgress ? (
-            <div className="d-flex align-items-center gap-3">
-              <img
-                height={30}
-                width={30}
-                src="https://i.gifer.com/origin/34/34338d26023e5515f6cc8969aa027bca.gif"
-              />
+          <div className="d-flex gap-3">
+            <img
+              height={30}
+              width={30}
+              src="https://i.gifer.com/origin/34/34338d26023e5515f6cc8969aa027bca.gif"
+            />
+            <div className="d-flex flex-column gap-2">
               <div className="flex-1 text-left">
-                Processing your request ...
+                Awaiting transaction confirmation...
               </div>
+
+              <button
+                onClick={cancelTxn}
+                className="btn btn-transparent"
+                style={{ width: "fit-content" }}
+              >
+                Cancel
+              </button>
             </div>
-          ) : (
-            <div className="d-flex align-items-center gap-3 ">
-              <i class="bi bi-exclamation-triangle h3 mb-0 warning-icon"></i>
-              <div className="flex-1 text-left">
-                Something went wrong. Please try resubmitting the request.
-              </div>
-            </div>
-          )}
+          </div>
         </div>
       </div>
     </div>

--- a/instances/widgets.treasury-factory.near/widget/components/VoteActions.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/VoteActions.jsx
@@ -81,14 +81,12 @@ function getProposalData() {
 useEffect(() => {
   if (isTxnCreated) {
     let checkTxnTimeout = null;
-    let errorTimeout = null;
 
     const checkForVoteOnProposal = () => {
       getProposalData()
         .then((proposal) => {
           if (JSON.stringify(proposal.votes) !== JSON.stringify(votes)) {
             checkProposalStatus();
-            clearTimeout(errorTimeout);
             clearTimeout(checkTxnTimeout);
             setTxnCreated(false);
           } else {
@@ -99,23 +97,14 @@ useEffect(() => {
           // if proposal data doesn't exist, it means the proposal is deleted
           checkProposalStatus();
           clearTimeout(checkTxnTimeout);
-          clearTimeout(errorTimeout);
           setTxnCreated(false);
         });
     };
 
     checkForVoteOnProposal();
 
-    // if in 20 seconds there is no change, show error condition
-    errorTimeout = setTimeout(() => {
-      setShowErrorToast(true);
-      setTxnCreated(false);
-      clearTimeout(checkTxnTimeout);
-    }, 25_000);
-
     return () => {
       clearTimeout(checkTxnTimeout);
-      clearTimeout(errorTimeout);
     };
   }
 }, [isTxnCreated]);
@@ -158,9 +147,8 @@ const InsufficientBalanceWarning = () => {
 return (
   <Container>
     <TransactionLoader
+      cancelTxn={() => setTxnCreated(false)}
       showInProgress={isTxnCreated}
-      showError={showErrorToast}
-      toggleToast={() => setShowErrorToast(false)}
     />
 
     <InsufficientBalanceWarning />

--- a/instances/widgets.treasury-factory.near/widget/components/templates/AppLayout.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/templates/AppLayout.jsx
@@ -139,6 +139,13 @@ const Theme = styled.div`
     display: none;
   }
 
+  .btn-transparent {
+    border: 1px solid var(--border-color);
+    :hover {
+      border: 1px solid var(--border-color);
+    }
+  }
+
   .text-right {
     text-align: end;
   }

--- a/instances/widgets.treasury-factory.near/widget/pages/dashboard/Chart.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/dashboard/Chart.jsx
@@ -63,9 +63,10 @@ const periodMap = {
 };
 
 function formatCurrency(amount) {
-  return Number(amount)
-    .toFixed(2)
-    .replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return Number(amount).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 }
 
 const config = treasuryDaoID ? Near.view(treasuryDaoID, "get_config") : null;

--- a/instances/widgets.treasury-factory.near/widget/pages/dashboard/Portfolio.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/dashboard/Portfolio.jsx
@@ -83,9 +83,10 @@ const [isNearStakedPortfolioExpanded, setNearStakedPortfolioExpanded] =
 const [showHiddenTokens, setShowHiddenTokens] = useState(false);
 
 function formatCurrency(amount) {
-  const formattedAmount = Number(amount)
-    .toFixed(2)
-    .replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  const formattedAmount = Number(amount).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
   return "$" + formattedAmount;
 }
 
@@ -130,7 +131,10 @@ const BalanceDisplay = ({
             <div className="d-flex flex-column align-items-end">
               <div className="h6 mb-0 d-flex align-items-center gap-1">
                 <NearToken height={20} width={20} />
-                {formatToReadableDecimals(balance)}
+                {Number(balance).toLocaleString("en-US", {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
               </div>
               <div className="text-sm text-secondary">
                 {formatCurrency(
@@ -198,7 +202,12 @@ const PortfolioCard = ({
           </div>
           <div className="d-flex gap-2 align-items-center justify-content-end">
             <div className="d-flex flex-column align-items-end">
-              <div className="h6 mb-0">{formatToReadableDecimals(balance)}</div>
+              <div className="h6 mb-0">
+                {Number(balance).toLocaleString("en-US", {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </div>
               <div className="text-sm text-secondary">
                 {formatCurrency(
                   formatToReadableDecimals(getPrice(balance, price))

--- a/instances/widgets.treasury-factory.near/widget/pages/dashboard/TransactionHistory.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/dashboard/TransactionHistory.jsx
@@ -105,9 +105,10 @@ function formatRelativeDate(date) {
 }
 
 function formatCurrency(amount) {
-  return Number(amount)
-    .toFixed(2)
-    .replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return Number(amount).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 }
 
 function getImage(actionKind) {

--- a/instances/widgets.treasury-factory.near/widget/pages/dashboard/index.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/dashboard/index.jsx
@@ -186,9 +186,10 @@ const totalBalance = Big(nearBalances?.totalParsed ?? "0")
   .toFixed(2);
 
 function formatCurrency(amount) {
-  const formattedAmount = Number(amount)
-    .toFixed(2)
-    .replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  const formattedAmount = Number(amount).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
   return "$" + formattedAmount;
 }
 

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/CreatePaymentRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/CreatePaymentRequest.jsx
@@ -482,7 +482,9 @@ return (
               instance,
               selectedValue: selectedWallet,
               onUpdate: (v) => {
-                cleanInputs();
+                if (v.value !== selectedWallet.value) {
+                  cleanInputs();
+                }
                 setSelectedWallet(v);
               },
             }}

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/CreatePaymentRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/CreatePaymentRequest.jsx
@@ -197,14 +197,13 @@ function cleanInputs() {
 useEffect(() => {
   if (isTxnCreated) {
     let checkTxnTimeout = null;
-    let errorTimeout = null;
 
     const checkForNewProposal = () => {
       getLastProposalId().then((id) => {
         if (typeof lastProposalId === "number" && lastProposalId !== id) {
           cleanInputs();
           onCloseCanvas();
-          clearTimeout(errorTimeout);
+          clearTimeout(checkTxnTimeout);
           refreshData();
           setTxnCreated(false);
         } else {
@@ -215,16 +214,8 @@ useEffect(() => {
 
     checkForNewProposal();
 
-    // if in 20 seconds there is no change, show error condition
-    errorTimeout = setTimeout(() => {
-      setShowErrorToast(true);
-      setTxnCreated(false);
-      clearTimeout(checkTxnTimeout);
-    }, 25_000);
-
     return () => {
       clearTimeout(checkTxnTimeout);
-      clearTimeout(errorTimeout);
     };
   }
 }, [isTxnCreated, lastProposalId]);
@@ -460,8 +451,7 @@ return (
   <Container>
     <TransactionLoader
       showInProgress={isTxnCreated}
-      showError={showErrorToast}
-      toggleToast={() => setShowErrorToast(false)}
+      cancelTxn={() => setTxnCreated(false)}
     />
     <Widget
       src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.Modal`}

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/DeleteModalConfirmation.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/DeleteModalConfirmation.jsx
@@ -43,14 +43,13 @@ useEffect(() => {
 useEffect(() => {
   if (isTxnCreated && typeof onRefresh === "function") {
     let checkTxnTimeout = null;
-    let errorTimeout = null;
 
     const checkForNewProposal = () => {
       getLastProposalId().then((id) => {
         if (typeof lastProposalId === "number" && lastProposalId !== id) {
           setToastStatus(true);
           setTxnCreated(false);
-          clearTimeout(errorTimeout);
+          clearTimeout(isTxnCreated);
         } else {
           checkTxnTimeout = setTimeout(() => checkForNewProposal(), 1000);
         }
@@ -58,16 +57,8 @@ useEffect(() => {
     };
     checkForNewProposal();
 
-    // if in 20 seconds there is no change, show error condition
-    errorTimeout = setTimeout(() => {
-      setShowErrorToast(true);
-      setTxnCreated(false);
-      clearTimeout(checkTxnTimeout);
-    }, 25_000);
-
     return () => {
       clearTimeout(checkTxnTimeout);
-      clearTimeout(errorTimeout);
     };
   }
 }, [isTxnCreated, onRefresh]);
@@ -232,8 +223,7 @@ return (
     {onRefresh && (
       <TransactionLoader
         showInProgress={isTxnCreated}
-        showError={showErrorToast}
-        toggleToast={() => setShowErrorToast(false)}
+        cancelTxn={() => setTxnCreated(false)}
       />
     )}
     <Modal hidden={!isOpen}>

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/MembersEditor.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/MembersEditor.jsx
@@ -59,14 +59,13 @@ useEffect(() => {
 useEffect(() => {
   if (isTxnCreated) {
     let checkTxnTimeout = null;
-    let errorTimeout = null;
 
     const checkForNewProposal = () => {
       getLastProposalId().then((id) => {
         if (typeof lastProposalId === "number" && lastProposalId !== id) {
           setToastStatus(true);
           onCloseCanvas();
-          clearTimeout(errorTimeout);
+          clearTimeout(checkTxnTimeout);
           setTxnCreated(false);
         } else {
           checkTxnTimeout = setTimeout(() => checkForNewProposal(), 1000);
@@ -75,16 +74,8 @@ useEffect(() => {
     };
     checkForNewProposal();
 
-    // if in 20 seconds there is no change, show error condition
-    errorTimeout = setTimeout(() => {
-      setShowErrorToast(true);
-      setTxnCreated(false);
-      clearTimeout(checkTxnTimeout);
-    }, 25_000);
-
     return () => {
       clearTimeout(checkTxnTimeout);
-      clearTimeout(errorTimeout);
     };
   }
 }, [isTxnCreated, lastProposalId]);
@@ -228,8 +219,7 @@ return (
   <Container className="d-flex flex-column gap-2">
     <TransactionLoader
       showInProgress={isTxnCreated}
-      showError={showErrorToast}
-      toggleToast={() => setShowErrorToast(false)}
+      cancelTxn={() => setTxnCreated(false)}
     />
     <Widget
       src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.Modal`}

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/Theme.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/Theme.jsx
@@ -263,14 +263,13 @@ useEffect(() => {
 useEffect(() => {
   if (isTxnCreated) {
     let checkTxnTimeout = null;
-    let errorTimeout = null;
 
     const checkForNewProposal = () => {
       getLastProposalId().then((id) => {
         if (typeof lastProposalId === "number" && lastProposalId !== id) {
           setToastStatus(true);
           setTxnCreated(false);
-          clearTimeout(errorTimeout);
+          clearTimeout(checkTxnTimeout);
         } else {
           checkTxnTimeout = setTimeout(() => checkForNewProposal(), 1000);
         }
@@ -278,16 +277,8 @@ useEffect(() => {
     };
     checkForNewProposal();
 
-    // if in 20 seconds there is no change, show error condition
-    errorTimeout = setTimeout(() => {
-      setShowErrorToast(true);
-      setTxnCreated(false);
-      clearTimeout(checkTxnTimeout);
-    }, 25_000);
-
     return () => {
       clearTimeout(checkTxnTimeout);
-      clearTimeout(errorTimeout);
     };
   }
 }, [isTxnCreated, lastProposalId]);
@@ -351,8 +342,7 @@ return (
     <SubmitToast />
     <TransactionLoader
       showInProgress={isTxnCreated}
-      showError={showErrorToast}
-      toggleToast={() => setShowErrorToast(false)}
+      cancelTxn={() => setTxnCreated(false)}
     />
     <div className="card rounded-4 w-100 h-100 py-3">
       <div className="card-title px-3 pb-3">Theme & Logo</div>

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/Thresholds.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/Thresholds.jsx
@@ -104,14 +104,13 @@ useEffect(() => {
 useEffect(() => {
   if (isTxnCreated) {
     let checkTxnTimeout = null;
-    let errorTimeout = null;
 
     const checkForNewProposal = () => {
       getLastProposalId().then((id) => {
         if (typeof lastProposalId === "number" && lastProposalId !== id) {
           setToastStatus(true);
           setTxnCreated(false);
-          clearTimeout(errorTimeout);
+          clearTimeout(checkTxnTimeout);
         } else {
           checkTxnTimeout = setTimeout(() => checkForNewProposal(), 1000);
         }
@@ -119,16 +118,8 @@ useEffect(() => {
     };
     checkForNewProposal();
 
-    // if in 20 seconds there is no change, show error condition
-    errorTimeout = setTimeout(() => {
-      setShowErrorToast(true);
-      setTxnCreated(false);
-      clearTimeout(checkTxnTimeout);
-    }, 25_000);
-
     return () => {
       clearTimeout(checkTxnTimeout);
-      clearTimeout(errorTimeout);
     };
   }
 }, [isTxnCreated, lastProposalId]);
@@ -322,8 +313,7 @@ return (
     <SubmitToast />
     <TransactionLoader
       showInProgress={isTxnCreated}
-      showError={showErrorToast}
-      toggleToast={() => setShowErrorToast(false)}
+      cancelTxn={() => setTxnCreated(false)}
     />
     {Array.isArray(rolesData) && rolesData.length && selectedGroup ? (
       <div className="card rounded-4 d-flex flex-row px-0 flex-wrap">

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/VotingDurationPage.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/VotingDurationPage.jsx
@@ -279,14 +279,13 @@ const submitChangeRequest = () => {
 useEffect(() => {
   if (isTxnCreated) {
     let checkTxnTimeout = null;
-    let errorTimeout = null;
 
     const checkForNewProposal = () => {
       getLastProposalId().then((id) => {
         if (typeof lastProposalId === "number" && lastProposalId !== id) {
           setToastStatus(true);
           setTxnCreated(false);
-          clearTimeout(errorTimeout);
+          clearTimeout(checkTxnTimeout);
         } else {
           checkTxnTimeout = setTimeout(() => checkForNewProposal(), 1000);
         }
@@ -294,16 +293,8 @@ useEffect(() => {
     };
     checkForNewProposal();
 
-    // if in 20 seconds there is no change, show error condition
-    errorTimeout = setTimeout(() => {
-      setShowErrorToast(true);
-      setTxnCreated(false);
-      clearTimeout(checkTxnTimeout);
-    }, 25_000);
-
     return () => {
       clearTimeout(checkTxnTimeout);
-      clearTimeout(errorTimeout);
     };
   }
 }, [isTxnCreated, lastProposalId]);
@@ -319,8 +310,7 @@ return (
   <Container>
     <TransactionLoader
       showInProgress={isTxnCreated}
-      showError={showErrorToast}
-      toggleToast={() => setShowErrorToast(false)}
+      cancelTxn={() => setTxnCreated(false)}
     />
     <div className="card rounded-4 py-3" style={{ maxWidth: "50rem" }}>
       <div className="card-title px-3 pb-3">Voting Duration</div>

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateStakeRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateStakeRequest.jsx
@@ -168,7 +168,11 @@ const BalanceDisplay = ({ label, balance, tooltipInfo, noBorder }) => {
             />
           </div>
           <div className="h6 mb-0 d-flex align-items-center gap-1">
-            {balance} NEAR
+            {Number(balance).toLocaleString("en-US", {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}{" "}
+            NEAR
           </div>
         </div>
       </div>
@@ -252,14 +256,16 @@ useEffect(() => {
 function getBalances() {
   switch (selectedWallet?.value) {
     case lockupContract: {
+      let available = Big(lockupNearBalances.totalParsed ?? "0")
+        .minus(lockupStakedTotalTokens ?? "0")
+        .minus(formatNearAmount(LOCKUP_MIN_BALANCE_FOR_STORAGE))
+        .toFixed(2);
+      available = parseFloat(available) < 0 ? 0 : available;
       return {
         staked: lockupStakedTokens,
         unstaked: lockupUnStakedTokens,
         withdrawal: lockupNearWithdrawTokens,
-        available: Big(lockupNearBalances.totalParsed ?? "0")
-          .minus(lockupStakedTotalTokens ?? "0")
-          .minus(formatNearAmount(LOCKUP_MIN_BALANCE_FOR_STORAGE))
-          .toFixed(2),
+        available,
       };
     }
     default:

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateStakeRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateStakeRequest.jsx
@@ -129,13 +129,12 @@ useEffect(() => {
 useEffect(() => {
   if (isTxnCreated) {
     let checkTxnTimeout = null;
-    let errorTimeout = null;
 
     const checkForNewProposal = () => {
       getLastProposalId().then((id) => {
         if (typeof lastProposalId === "number" && lastProposalId !== id) {
           onCloseCanvas();
-          clearTimeout(errorTimeout);
+          clearTimeout(checkTxnTimeout);
           refreshData();
           setTxnCreated(false);
         } else {
@@ -145,16 +144,8 @@ useEffect(() => {
     };
     checkForNewProposal();
 
-    // if in 20 seconds there is no change, show error condition
-    errorTimeout = setTimeout(() => {
-      setShowErrorToast(true);
-      setTxnCreated(false);
-      clearTimeout(checkTxnTimeout);
-    }, 25_000);
-
     return () => {
       clearTimeout(checkTxnTimeout);
-      clearTimeout(errorTimeout);
     };
   }
 }, [isTxnCreated, lastProposalId]);
@@ -417,8 +408,7 @@ return (
   <Container>
     <TransactionLoader
       showInProgress={isTxnCreated}
-      showError={showErrorToast}
-      toggleToast={() => setShowErrorToast(false)}
+      cancelTxn={() => setTxnCreated(false)}
     />
     <Widget
       src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.Modal`}
@@ -459,6 +449,7 @@ return (
               instance,
               selectedValue: selectedWallet,
               onUpdate: (v) => {
+                setValidatorAccount(null);
                 setSelectedWallet(v);
               },
             }}
@@ -502,8 +493,10 @@ return (
             availableBalance: getBalances().available,
             instance,
             onCancel: () => setShowCancelModal(true),
-            onSubmit: (validatorAccount, amount, notes) =>
-              onSubmitClick(validatorAccount, amount, notes),
+            onSubmit: (validatorAccount, amount, notes, selectedOption) => {
+              onSubmitClick(validatorAccount, amount, notes);
+              setValidatorAccount(selectedOption);
+            },
             lockupStakedPoolId,
             isStakePage: true,
           }}

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateUnstakeRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateUnstakeRequest.jsx
@@ -220,7 +220,11 @@ const BalanceDisplay = ({ label, balance, tooltipInfo, noBorder }) => {
             />
           </div>
           <div className="h6 mb-0 d-flex align-items-center gap-1">
-            {balance} NEAR
+            {Number(balance).toLocaleString("en-US", {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}{" "}
+            NEAR
           </div>
         </div>
       </div>
@@ -231,14 +235,16 @@ const BalanceDisplay = ({ label, balance, tooltipInfo, noBorder }) => {
 function getBalances() {
   switch (selectedWallet?.value) {
     case lockupContract: {
+      let available = Big(lockupNearBalances.totalParsed ?? "0")
+        .minus(lockupStakedTotalTokens ?? "0")
+        .minus(formatNearAmount(LOCKUP_MIN_BALANCE_FOR_STORAGE))
+        .toFixed(2);
+      available = parseFloat(available) < 0 ? 0 : available;
       return {
         staked: lockupStakedTokens,
         unstaked: lockupUnStakedTokens,
         withdrawal: lockupNearWithdrawTokens,
-        available: Big(lockupNearBalances.totalParsed ?? "0")
-          .minus(lockupStakedTotalTokens ?? "0")
-          .minus(formatNearAmount(LOCKUP_MIN_BALANCE_FOR_STORAGE))
-          .toFixed(2),
+        available,
       };
     }
     default:

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateWithdrawRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateWithdrawRequest.jsx
@@ -119,14 +119,13 @@ useEffect(() => {
 useEffect(() => {
   if (isTxnCreated) {
     let checkTxnTimeout = null;
-    let errorTimeout = null;
 
     const checkForNewProposal = () => {
       getLastProposalId().then((id) => {
         if (typeof lastProposalId === "number" && lastProposalId !== id) {
           onCloseCanvas();
           refreshData();
-          clearTimeout(errorTimeout);
+          clearTimeout(checkTxnTimeout);
           setTxnCreated(false);
         } else {
           checkTxnTimeout = setTimeout(() => checkForNewProposal(), 1000);
@@ -135,16 +134,8 @@ useEffect(() => {
     };
     checkForNewProposal();
 
-    // if in 20 seconds there is no change, show error condition
-    errorTimeout = setTimeout(() => {
-      setShowErrorToast(true);
-      setTxnCreated(false);
-      clearTimeout(checkTxnTimeout);
-    }, 25_000);
-
     return () => {
       clearTimeout(checkTxnTimeout);
-      clearTimeout(errorTimeout);
     };
   }
 }, [isTxnCreated, lastProposalId]);
@@ -382,8 +373,7 @@ return (
   <Container>
     <TransactionLoader
       showInProgress={isTxnCreated}
-      showError={showErrorToast}
-      toggleToast={() => setShowErrorToast(false)}
+      cancelTxn={() => setTxnCreated(false)}
     />
     <Widget
       src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.StakedNearIframe`}

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateWithdrawRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateWithdrawRequest.jsx
@@ -158,7 +158,11 @@ const BalanceDisplay = ({ label, balance, tooltipInfo, noBorder }) => {
             />
           </div>
           <div className="h6 mb-0 d-flex align-items-center gap-1">
-            {balance} NEAR
+            {Number(balance).toLocaleString("en-US", {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}{" "}
+            NEAR
           </div>
         </div>
       </div>
@@ -169,14 +173,16 @@ const BalanceDisplay = ({ label, balance, tooltipInfo, noBorder }) => {
 function getBalances() {
   switch (selectedWallet?.value) {
     case lockupContract: {
+      let available = Big(lockupNearBalances.totalParsed ?? "0")
+        .minus(lockupStakedTotalTokens ?? "0")
+        .minus(formatNearAmount(LOCKUP_MIN_BALANCE_FOR_STORAGE))
+        .toFixed(2);
+      available = parseFloat(available) < 0 ? 0 : available;
       return {
         staked: lockupStakedTokens,
         unstaked: lockupUnStakedTokens,
         withdrawal: lockupNearWithdrawTokens,
-        available: Big(lockupNearBalances.totalParsed ?? "0")
-          .minus(lockupStakedTotalTokens ?? "0")
-          .minus(formatNearAmount(LOCKUP_MIN_BALANCE_FOR_STORAGE))
-          .toFixed(2),
+        available,
       };
     }
     default:

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/ValidatorsDropDownWithSearch.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/ValidatorsDropDownWithSearch.jsx
@@ -419,7 +419,8 @@ const code = `
             handler: "onSubmit", 
             notes: notesInput.value, 
             amount: amountInput.value, 
-            validatorAccount: selectedOption.pool_id 
+            validatorAccount: selectedOption.pool_id,
+            selectedOption 
         }, 
             "*"
         );
@@ -510,7 +511,7 @@ return (
           break;
         }
         case "onSubmit": {
-          onSubmit(e.validatorAccount, e.amount, e.notes);
+          onSubmit(e.validatorAccount, e.amount, e.notes, e.selectedOption);
           break;
         }
         case "updateIframeHeight": {

--- a/playwright-tests/tests/payments/create-payment-request.spec.js
+++ b/playwright-tests/tests/payments/create-payment-request.spec.js
@@ -732,6 +732,7 @@ test.describe("User is logged in", function () {
     instanceAccount,
   }) => {
     test.setTimeout(100_000);
+    await updateDaoPolicyMembers({ instanceAccount, page });
     await fillCreateForm(page, daoAccount, instanceAccount);
     const submitBtn = page
       .locator(".offcanvas-body")
@@ -953,7 +954,7 @@ test.describe("admin with function access keys", function () {
     });
     await expect(
       page.getByRole("cell", { name: `${newProposalId}`, exact: true })
-    ).toBeVisible({ timeout: 10_000 });
+    ).toBeVisible({ timeout: 20_000 });
     const widgetsAccount =
       (instanceAccount.includes("testing") ? "test-widgets" : "widgets") +
       ".treasury-factory.near";
@@ -967,31 +968,28 @@ test.describe("admin with function access keys", function () {
     );
 
     const checkThatFormIsCleared = async () => {
+      await page.waitForTimeout(2_000);
       await page.getByRole("button", { name: " Create Request" }).click();
 
       if (instanceConfig.showProposalSelection === true) {
         const proposalSelect = page.locator(".dropdown-toggle").first();
         await expect(proposalSelect).toBeVisible();
-
         await expect(
           proposalSelect.getByText("Select", { exact: true })
         ).toBeVisible();
       } else {
-        await expect(page.getByTestId("proposal-title")).toHaveText("");
-        await expect(page.getByTestId("proposal-summary")).toHaveText("");
-
+        await expect(page.getByTestId("proposal-title")).toHaveValue("");
+        await expect(page.getByTestId("proposal-summary")).toHaveValue("");
         await expect(page.getByPlaceholder("treasury.near")).toBeVisible();
-
-        await expect(page.getByTestId("total-amount")).toHaveText("");
+        await expect(page.getByTestId("total-amount")).toHaveValue("");
       }
       const submitBtn = page.getByRole("button", { name: "Submit" });
       await expect(submitBtn).toBeAttached({ timeout: 10_000 });
       await expect(submitBtn).toBeDisabled({ timeout: 10_000 });
     };
     await checkThatFormIsCleared();
-
+    await page.waitForTimeout(2_000);
     await page.reload();
-
     await checkThatFormIsCleared();
   });
 });

--- a/playwright-tests/tests/payments/vote-on-request.spec.js
+++ b/playwright-tests/tests/payments/vote-on-request.spec.js
@@ -278,7 +278,9 @@ test.describe("don't ask again", function () {
     await expect(approveButton).toBeEnabled({ timeout: 30_000 });
     await approveButton.click();
     await page.getByRole("button", { name: "Confirm" }).click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
     await expect(approveButton).toBeDisabled();
 
     const transaction_toast = page.getByText(
@@ -334,7 +336,9 @@ test.describe("don't ask again", function () {
     await expect(rejectButton).toBeEnabled({ timeout: 10000 });
     await rejectButton.click();
     await page.getByRole("button", { name: "Confirm" }).click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
     await expect(rejectButton).toBeDisabled();
 
     const transaction_toast = page.getByText(
@@ -390,7 +394,9 @@ test.describe("don't ask again", function () {
       page.getByText("Do you really want to delete this request?")
     ).toBeVisible();
     await page.getByRole("button", { name: "Confirm" }).click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
 
     await expect(deleteButton).toBeDisabled();
 
@@ -412,6 +418,37 @@ test.describe("don't ask again", function () {
         page.getByText("The payment request has been successfully deleted.")
       ).toBeVisible();
     }
+  });
+
+  test("submit action should show transaction loader and handle cancellation correctly", async ({
+    page,
+    daoAccount,
+    instanceAccount,
+  }) => {
+    test.setTimeout(100_000);
+    await mockPaymentProposals({ page });
+    await mockWithFTBalance({ page, daoAccount, isSufficient: true });
+    await mockPikespeakFTTokensResponse({ page, daoAccount });
+    await updateDaoPolicyMembers({ instanceAccount, page, isMultiVote: false });
+    await page.goto(`/${instanceAccount}/widget/app?page=payments`);
+    const approveButton = page
+      .getByRole("button", {
+        name: "Approve",
+      })
+      .first();
+    await expect(approveButton).toBeEnabled({ timeout: 30_000 });
+    await approveButton.click();
+    await page.getByRole("button", { name: "Confirm" }).click();
+    const loader = page.getByText("Awaiting transaction confirmation...");
+    await expect(loader).toBeVisible();
+    await expect(approveButton).toBeDisabled();
+    await page.getByRole("button", { name: "Close" }).nth(1).click();
+    await page
+      .locator(".toast-body")
+      .getByRole("button", { name: "Cancel" })
+      .click();
+    await expect(loader).toBeHidden();
+    await expect(approveButton).toBeEnabled();
   });
 });
 

--- a/playwright-tests/tests/payments/vote-on-request.spec.js
+++ b/playwright-tests/tests/payments/vote-on-request.spec.js
@@ -437,6 +437,17 @@ test.describe("don't ask again", function () {
       })
       .first();
     await expect(approveButton).toBeEnabled({ timeout: 30_000 });
+    await mockRpcRequest({
+      page,
+      filterParams: {
+        method_name: "get_proposal",
+      },
+      modifyOriginalResultFunction: (originalResult) => {
+        originalResult = TransferProposalData;
+        originalResult.status = "InProgress";
+        return originalResult;
+      },
+    });
     await approveButton.click();
     await page.getByRole("button", { name: "Confirm" }).click();
     const loader = page.getByText("Awaiting transaction confirmation...");

--- a/playwright-tests/tests/settings/create-member-request.spec.js
+++ b/playwright-tests/tests/settings/create-member-request.spec.js
@@ -218,7 +218,9 @@ test.describe("User is logged in", function () {
     const submitBtn = await page.locator("button", { hasText: "Submit" });
     await submitBtn.scrollIntoViewIfNeeded({ timeout: 10_000 });
     await submitBtn.click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
     const description = {
       title: "Update policy - Members Permissions",
       summary: `theori.near requested to add "${account}" to "${permission}".`,
@@ -408,7 +410,9 @@ test.describe("User is logged in", function () {
     await expect(submitBtn).toBeAttached({ timeout: 10_000 });
     await submitBtn.scrollIntoViewIfNeeded({ timeout: 10_000 });
     await submitBtn.click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
     const description = {
       title: "Update policy - Members Permissions",
       summary: `theori.near requested to remove "${account}" from "${permission}".`,
@@ -467,7 +471,9 @@ test.describe("User is logged in", function () {
       page.getByRole("heading", { name: "Are you sure?" })
     ).toBeVisible();
     await page.getByRole("button", { name: "Remove" }).click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
 
     const description = {
       title: "Update policy - Members Permissions",
@@ -510,5 +516,34 @@ test.describe("User is logged in", function () {
         },
       },
     });
+  });
+  test("submit action should show transaction loader and handle cancellation correctly", async ({
+    page,
+    instanceAccount,
+  }) => {
+    test.setTimeout(100_000);
+    const account = "testingaccount.near";
+    const hasNewPolicy = instanceAccount.includes("testing");
+    const permission = hasNewPolicy ? "Requestor" : "Create Requests";
+    await openAddMemberForm({ page });
+    const accountInput = page.getByPlaceholder("treasury.near");
+    await accountInput.focus();
+    accountInput.fill(account);
+    await accountInput.blur();
+    await page.locator(".dropdown-toggle", { hasText: "Select" }).click();
+    await page.locator(".dropdown-item", { hasText: permission }).click();
+    const submitBtn = await page.locator("button", { hasText: "Submit" });
+    await submitBtn.scrollIntoViewIfNeeded({ timeout: 10_000 });
+    await submitBtn.click();
+    const loader = page.getByText("Awaiting transaction confirmation...");
+    await expect(loader).toBeVisible();
+    await expect(submitBtn).toBeDisabled();
+    await page.getByRole("button", { name: "Close" }).nth(1).click();
+    await page
+      .locator(".toast-body")
+      .getByRole("button", { name: "Cancel" })
+      .click();
+    await expect(loader).toBeHidden();
+    await expect(submitBtn).toBeEnabled();
   });
 });

--- a/playwright-tests/tests/settings/create-threshold-request.spec.js
+++ b/playwright-tests/tests/settings/create-threshold-request.spec.js
@@ -228,7 +228,9 @@ test.describe("User is logged in", function () {
       )
     ).toBeVisible();
     await page.getByRole("button", { name: "Confirm" }).click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
     const updatedPolicy = {
       weight_kind: "RoleWeight",
       quorum: "0",
@@ -275,7 +277,9 @@ test.describe("User is logged in", function () {
     await submitBtn.click();
     await expect(page.getByText("Are you sure?")).toBeVisible();
     await page.getByRole("button", { name: "Confirm" }).click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
 
     const updatedPolicy = {
       weight_kind: "RoleWeight",
@@ -356,7 +360,30 @@ test.describe("User is logged in", function () {
     await submitBtn.click();
     await expect(page.getByText("Are you sure?")).toBeVisible();
     await page.getByRole("button", { name: "Confirm" }).click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
+  });
+
+  test("submit action should show transaction loader and handle cancellation correctly", async ({
+    page,
+  }) => {
+    test.setTimeout(100_000);
+    const thresholdInput = page.getByTestId("threshold-input");
+    await thresholdInput.fill("3");
+    const submitBtn = page.getByRole("button", { name: "Submit Request" });
+    await submitBtn.click();
+    await page.getByRole("button", { name: "Confirm" }).click();
+    const loader = page.getByText("Awaiting transaction confirmation...");
+    await expect(loader).toBeVisible();
+    await expect(submitBtn).toBeDisabled();
+    await page.getByRole("button", { name: "Close" }).nth(1).click();
+    await page
+      .locator(".toast-body")
+      .getByRole("button", { name: "Cancel" })
+      .click();
+    await expect(loader).toBeHidden();
+    await expect(submitBtn).toBeEnabled();
   });
 
   test("should show correct threshold with default policy", async ({

--- a/playwright-tests/tests/settings/request-feed.spec.js
+++ b/playwright-tests/tests/settings/request-feed.spec.js
@@ -372,16 +372,25 @@ test.describe("don't ask again", function () {
   }) => {
     test.setTimeout(100_000);
     await updateDaoPolicyMembers({ instanceAccount, page });
+    const proposalData = JSON.parse(JSON.stringify(SettingsProposalData));
+    proposalData.submission_time = CurrentTimestampInNanoseconds;
+    proposalData.status = "InProgress";
     await mockRpcRequest({
       page,
       filterParams: {
         method_name: "get_proposals",
       },
-      modifyOriginalResultFunction: (originalResult) => {
-        originalResult = JSON.parse(JSON.stringify(SettingsProposalData));
-        originalResult.submission_time = CurrentTimestampInNanoseconds;
-        originalResult.status = "InProgress";
-        return originalResult;
+      modifyOriginalResultFunction: () => {
+        return [proposalData];
+      },
+    });
+    await mockRpcRequest({
+      page,
+      filterParams: {
+        method_name: "get_proposal",
+      },
+      modifyOriginalResultFunction: () => {
+        return proposalData;
       },
     });
     await page.goto(`/${instanceAccount}/widget/app?page=settings`);

--- a/playwright-tests/tests/settings/theme.spec.js
+++ b/playwright-tests/tests/settings/theme.spec.js
@@ -161,7 +161,9 @@ test.describe("User is logged in", function () {
     await expect(submitBtn).toBeDisabled(submitBtn);
     await logoInput.setInputFiles(path.join(__dirname, "./assets/valid.jpg"));
     await submitBtn.click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
 
     await expect(await getTransactionModalObject(page)).toEqual({
       proposal: {
@@ -188,7 +190,9 @@ test.describe("User is logged in", function () {
     await page.getByTestId("dropdown-btn").click();
     await page.getByText("Light").click();
     await page.getByRole("button", { name: "Submit Request" }).click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    await expect(
+      page.getByText("Awaiting transaction confirmation...")
+    ).toBeVisible();
     await expect(await getTransactionModalObject(page)).toEqual({
       proposal: {
         description: "* Title: Update Config - Theme & logo",
@@ -208,17 +212,21 @@ test.describe("User is logged in", function () {
     });
   });
 
-  test("should display a transaction error toast when the transaction confirmation modal is canceled", async ({
+  test("submit action should show transaction loader and handle cancellation correctly", async ({
     page,
   }) => {
-    test.setTimeout(150_000);
-    await page.getByRole("button", { name: "Submit Request" }).click();
-    await expect(page.getByText("Processing your request ...")).toBeVisible();
+    test.setTimeout(100_000);
+    const submitBtn = page.getByRole("button", { name: "Submit Request" });
+    await submitBtn.click();
+    const loader = page.getByText("Awaiting transaction confirmation...");
+    await expect(loader).toBeVisible();
+    await expect(submitBtn).toBeDisabled();
     await page.getByRole("button", { name: "Close" }).nth(1).click();
-    await expect(
-      page.getByText(
-        "Something went wrong. Please try resubmitting the request"
-      )
-    ).toBeVisible({ timeout: 30_000 });
+    await page
+      .locator(".toast-body")
+      .getByRole("button", { name: "Cancel" })
+      .click();
+    await expect(loader).toBeHidden();
+    await expect(submitBtn).toBeEnabled();
   });
 });

--- a/playwright-tests/tests/settings/voting-duration.spec.js
+++ b/playwright-tests/tests/settings/voting-duration.spec.js
@@ -478,10 +478,20 @@ test.describe("User is logged in", function () {
     await durationInput.fill("3");
     const submitBtn = page.getByRole("button", { name: "Submit Request" });
     await submitBtn.click();
+    await expect(submitBtn).toBeDisabled();
+    await page.waitForTimeout(2_000);
+    const proceedButton = await page.locator(".modalfooter button", {
+      hasText: "Yes, proceed",
+    });
+
+    if (await proceedButton.isVisible({})) {
+      await proceedButton.click();
+    }
+
+    await page.getByRole("button", { name: "Close" }).nth(1).click();
+
     const loader = page.getByText("Awaiting transaction confirmation...");
     await expect(loader).toBeVisible();
-    await expect(submitBtn).toBeDisabled();
-    await page.getByRole("button", { name: "Close" }).nth(1).click();
     await page
       .locator(".toast-body")
       .getByRole("button", { name: "Cancel" })

--- a/playwright-tests/tests/settings/voting-duration.spec.js
+++ b/playwright-tests/tests/settings/voting-duration.spec.js
@@ -466,4 +466,27 @@ test.describe("User is logged in", function () {
       newDurationDays--;
     }
   });
+
+  test("submit action should show transaction loader and handle cancellation correctly", async ({
+    page,
+    instanceAccount,
+  }) => {
+    test.setTimeout(100_000);
+    await updateDaoPolicyMembers({ instanceAccount, page });
+    await navigateToVotingDurationPage({ page, instanceAccount });
+    const durationInput = page.getByPlaceholder("Enter voting duration days");
+    await durationInput.fill("3");
+    const submitBtn = page.getByRole("button", { name: "Submit Request" });
+    await submitBtn.click();
+    const loader = page.getByText("Awaiting transaction confirmation...");
+    await expect(loader).toBeVisible();
+    await expect(submitBtn).toBeDisabled();
+    await page.getByRole("button", { name: "Close" }).nth(1).click();
+    await page
+      .locator(".toast-body")
+      .getByRole("button", { name: "Cancel" })
+      .click();
+    await expect(loader).toBeHidden();
+    await expect(submitBtn).toBeEnabled();
+  });
 });

--- a/playwright-tests/tests/stake-delegation/stake-delegation.spec.js
+++ b/playwright-tests/tests/stake-delegation/stake-delegation.spec.js
@@ -807,6 +807,36 @@ test.describe("Have valid staked requests and sufficient token balance", functio
 
       await sandbox.quitSandbox();
     });
+
+    test("submit action should show transaction loader and handle cancellation correctly", async ({
+      page,
+    }) => {
+      test.setTimeout(150_000);
+      await openUnstakeForm({ page });
+      await fillValidatorAccount({
+        page,
+      });
+      await checkForStakeAmount({
+        page,
+        availableBalance: stakedNear,
+        errorText: "The amount exceeds the balance you have staked.",
+      });
+      const submitBtn = await page
+        .frameLocator("iframe")
+        .nth(1)
+        .getByRole("button", { name: "Submit" });
+      await submitBtn.click();
+      const loader = page.getByText("Awaiting transaction confirmation...");
+      await expect(loader).toBeVisible();
+      await expect(submitBtn).toBeDisabled();
+      await page.getByRole("button", { name: "Close" }).nth(1).click();
+      await page
+        .locator(".toast-body")
+        .getByRole("button", { name: "Cancel" })
+        .click();
+      await expect(loader).toBeHidden();
+      await expect(submitBtn).toBeEnabled();
+    });
   });
 });
 
@@ -1152,7 +1182,9 @@ test.describe("Lockup staking", function () {
         .nth(1)
         .getByRole("button", { name: "Submit" })
         .click();
-      await expect(page.getByText("Processing your request ...")).toBeVisible();
+      await expect(
+        page.getByText("Awaiting transaction confirmation...")
+      ).toBeVisible();
 
       await expect(await getTransactionModalObject(page)).toEqual({
         proposal: {
@@ -1282,7 +1314,9 @@ test.describe("Lockup staking", function () {
         .nth(1)
         .getByRole("button", { name: "Submit" })
         .click();
-      await expect(page.getByText("Processing your request ...")).toBeVisible();
+      await expect(
+        page.getByText("Awaiting transaction confirmation...")
+      ).toBeVisible();
 
       await expect(await getTransactionModalObject(page)).toEqual({
         proposal: {
@@ -1338,7 +1372,9 @@ test.describe("Lockup staking", function () {
         .nth(1)
         .getByRole("button", { name: "Submit" })
         .click();
-      await expect(page.getByText("Processing your request ...")).toBeVisible();
+      await expect(
+        page.getByText("Awaiting transaction confirmation...")
+      ).toBeVisible();
 
       await expect(await getTransactionModalObject(page)).toEqual({
         proposal: {


### PR DESCRIPTION
Keep checking for user transaction, until user clicks 'Cancel', added tests to confirm everything is enabled back after user 'Cancel' (in all pages)
<img width="346" alt="image" src="https://github.com/user-attachments/assets/623f707d-43ee-49a6-af47-93f48b81e786" />
