### PR TITLE
Fix sorting of tokens display in dashboard according to price, amount and token symbol length

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/components/Navbar.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/Navbar.jsx
@@ -123,7 +123,9 @@ function getTitle(text) {
   return text.replace(/-/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-const treasuryLogo = metadata?.flagLogo ? metadata?.flagLogo : logo;
+const treasuryLogo = metadata?.flagLogo?.includes("ipfs")
+  ? metadata?.flagLogo
+  : logo;
 
 return (
   <Navbar className="position-relative d-flex justify-content-between gap-2">

--- a/instances/widgets.treasury-factory.near/widget/components/Navbar.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/Navbar.jsx
@@ -123,7 +123,7 @@ function getTitle(text) {
   return text.replace(/-/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-const treasuryLogo = metadata?.flagLogo?.includes("ipfs")
+const treasuryLogo = (metadata?.flagLogo ?? "")?.includes("ipfs")
   ? metadata?.flagLogo
   : logo;
 

--- a/instances/widgets.treasury-factory.near/widget/pages/dashboard/Portfolio.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/dashboard/Portfolio.jsx
@@ -347,7 +347,6 @@ useEffect(() => {
   const tokenEvaluation = (token) =>
     parseInt(token.amount) / Math.pow(10, token.ft_meta.decimals ?? 1);
 
-  // Single pass to separate tokens with and without price
   const { tokensWithPrice, tokensWithoutPrice } = ftTokens.reduce(
     (acc, token) => {
       (token.ft_meta.price ? acc.tokensWithPrice : acc.tokensWithoutPrice).push(
@@ -368,7 +367,6 @@ useEffect(() => {
     (a, b) => tokenEvaluation(b) - tokenEvaluation(a)
   );
 
-  // Merge sorted lists
   const sortedTokens = [...sortedWithPrice, ...sortedWithoutPrice];
 
   // Separate validTokens (max 7) and remainingTokens

--- a/instances/widgets.treasury-factory.near/widget/pages/dashboard/Portfolio.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/dashboard/Portfolio.jsx
@@ -318,44 +318,46 @@ const NearPortfolio = () => {
 const isLoading =
   ftTokens === null || nearBalances === null || nearPrice === null;
 
-const unlistedTokens = Array.isArray(ftTokens)
-  ? ftTokens.filter(
-      (token) =>
-        token.ft_meta.symbol.length > 6 && /\./.test(token.ft_meta.symbol)
-    )
-  : [];
-
-const TokensList = ({ tokens, filterFn }) => {
+const TokensList = ({ tokens }) => {
   if (!Array.isArray(tokens)) return <></>;
-  if (tokens.filter(filterFn)?.length <= 0) return <></>;
 
   const sortTokens = (tokens) => {
     const tokenEvaluation = (token) =>
-      (parseInt(token.amount) * token.ft_meta.price) /
+      (parseInt(token.amount) * token.ft_meta.price ?? 0) /
       Math.pow(10, token.ft_meta.decimals ?? 1);
 
     return tokens.sort((a, b) => tokenEvaluation(b) - tokenEvaluation(a));
   };
 
-  return sortTokens(tokens)
-    ?.filter(filterFn)
-    ?.map((item, index) => {
-      const { ft_meta, amount } = item;
-      const { decimals, symbol, icon, price } = ft_meta;
-      const tokensNumber = convertBalanceToReadableFormat(amount, decimals);
+  return sortTokens(tokens)?.map((item, index) => {
+    const { ft_meta, amount } = item;
+    const { decimals, symbol, icon, price } = ft_meta;
+    const tokensNumber = convertBalanceToReadableFormat(amount, decimals);
 
-      return (
-        <PortfolioCard
-          hideBorder={index === ftTokens.length - 1}
-          symbol={symbol}
-          src={icon}
-          balance={tokensNumber}
-          showExpand={false}
-          price={price ?? 0}
-        />
-      );
-    });
+    return (
+      <PortfolioCard
+        hideBorder={index === ftTokens.length - 1}
+        symbol={symbol}
+        src={icon}
+        balance={tokensNumber}
+        showExpand={false}
+        price={price ?? 0}
+      />
+    );
+  });
 };
+
+const { validTokens, remainingTokens } = (ftTokens ?? []).reduce(
+  (acc, token) => {
+    if (token?.ft_meta?.symbol?.length <= 12 && !/\./.test(token?.ft_meta?.symbol)) {
+      acc.validTokens.push(token);
+    } else {
+      acc.remainingTokens.push(token);
+    }
+    return acc;
+  },
+  { validTokens: [], remainingTokens: [] }
+);
 
 return (
   <div className="card flex-1 overflow-hidden border-bottom">
@@ -372,25 +374,10 @@ return (
           ) : (
             <div className="d-flex flex-column">
               <NearPortfolio />
-              <TokensList
-                tokens={ftTokens}
-                filterFn={(token) =>
-                  token.ft_meta.symbol.length <= 6 &&
-                  !/\./.test(token.ft_meta.symbol)
-                }
-              />
-
-              {unlistedTokens.length > 0 && (
+              <TokensList tokens={validTokens} />
+              {remainingTokens.length > 0 && (
                 <>
-                  {showHiddenTokens && (
-                    <TokensList
-                      tokens={ftTokens}
-                      filterFn={(token) =>
-                        token.ft_meta.symbol.length > 6 &&
-                        /\./.test(token.ft_meta.symbol)
-                      }
-                    />
-                  )}
+                  {showHiddenTokens && <TokensList tokens={remainingTokens} />}
                   <div
                     role="button"
                     className="d-flex align-items-center justify-content-between px-3 py-2"

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/Theme.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/Theme.jsx
@@ -324,7 +324,9 @@ function onSubmitClick() {
 }
 
 function setDefault() {
-  setImage(metadata?.flagLogo ?? defaultImage);
+  setImage(
+    metadata?.flagLogo?.includes("ipfs") ? metadata.flagLogo : defaultImage
+  );
   setColor(metadata?.primaryColor ?? themeColor ?? defaultColor);
   setSelectedTheme(
     ThemeOptions.find((i) => i.value === metadata?.theme) ?? ThemeOptions[0]

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/Theme.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/Theme.jsx
@@ -325,7 +325,9 @@ function onSubmitClick() {
 
 function setDefault() {
   setImage(
-    metadata?.flagLogo?.includes("ipfs") ? metadata.flagLogo : defaultImage
+    (metadata?.flagLogo ?? "")?.includes("ipfs")
+      ? metadata.flagLogo
+      : defaultImage
   );
   setColor(metadata?.primaryColor ?? themeColor ?? defaultColor);
   setSelectedTheme(


### PR DESCRIPTION
Some tokens were hidden with the existing logic (like one with less than 6 letters and with a .)
We show the ones with `price, <6 symbol length and w/o ".",` and only 7 items, more can be viewed with expand, also fixed the sorting

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/2ee95b94-9163-4cc7-b68d-f9136c48a436" />
<img width="437" alt="image" src="https://github.com/user-attachments/assets/267cca81-6abe-4f17-942b-0bd31e1f230f" />
