### PR TITLE
Fix total calculation in dashboard

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/components/TokensDropdown.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/TokensDropdown.jsx
@@ -78,9 +78,7 @@ useEffect(() => {
       icon: NearToken,
       title: "NEAR",
       value: "NEAR",
-      tokenBalance: isLockupContract
-        ? nearBalances.availableParsed
-        : nearBalances.totalParsed,
+      tokenBalance: nearBalances.availableParsed,
     },
   ];
 
@@ -105,23 +103,13 @@ useEffect(() => {
 const [isOpen, setIsOpen] = useState(false);
 const [selectedOptionValue, setSelectedValue] = useState(selectedValue);
 
-function getNearAvailableBalance(tokenBalance) {
-  return Big(tokenBalance)
-    .minus(nearBalances.storageParsed ?? "0")
-    .minus(nearStakedTokens ?? "0")
-    .toFixed(2);
-}
 const toggleDropdown = () => {
   setIsOpen(!isOpen);
 };
 
 function sendTokensAvailable(value) {
   const balance = options.find((i) => i.value === value)?.tokenBalance;
-  return setTokensAvailable(
-    value === "NEAR" && !isLockupContract
-      ? getNearAvailableBalance(balance)
-      : balance
-  );
+  return setTokensAvailable(balance);
 }
 
 useEffect(() => {
@@ -209,10 +197,7 @@ const Item = ({ option }) => {
           </div>
         )}
         <div className="text-sm text-secondary w-100 text-wrap">
-          Tokens available:{" "}
-          {option.value === "NEAR" && !isLockupContract
-            ? getNearAvailableBalance(option.tokenBalance)
-            : option.tokenBalance}
+          Tokens available: {option.tokenBalance}
         </div>
       </div>
     </div>

--- a/instances/widgets.treasury-factory.near/widget/pages/dashboard/Portfolio.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/dashboard/Portfolio.jsx
@@ -253,12 +253,9 @@ const PortfolioCard = ({
 };
 
 const NearPortfolio = () => {
-  let available = Big(nearBalances?.availableParsed ?? "0")
-    .minus(nearStakedTotalTokens ?? "0")
+  let total = Big(nearBalances?.totalParsed ?? "0")
+    .plus(nearStakedTotalTokens ?? "0")
     .toFixed(2);
-  if (parseFloat(available) < 0) {
-    available = 0;
-  }
 
   const tooltipInfo = isLockupContract
     ? {
@@ -282,7 +279,7 @@ const NearPortfolio = () => {
       symbol={"NEAR"}
       hideBorder={!ftTokens?.length && !isNearPortfolioExpanded}
       Icon={NearToken}
-      balance={nearBalances.totalParsed}
+      balance={isLockupContract ? nearBalances.totalParsed : total}
       showExpand={true}
       price={nearPrice}
       isExpanded={isNearPortfolioExpanded}
@@ -291,10 +288,8 @@ const NearPortfolio = () => {
         <div className="d-flex flex-column">
           <BalanceDisplay
             label={"Available Balance"}
-            balance={
-              isLockupContract ? nearBalances.availableParsed : available
-            }
-            tooltipInfo={tooltipInfo?.available}
+            balance={nearBalances?.availableParsed}
+            tooltipInfo={TooltipText?.available}
             price={nearPrice}
           />
 

--- a/instances/widgets.treasury-factory.near/widget/pages/dashboard/index.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/dashboard/index.jsx
@@ -228,6 +228,7 @@ useEffect(() => {
 
 const totalBalance = Big(nearBalances?.totalParsed ?? "0")
   .mul(nearPrice ?? 1)
+  .plus(Big(nearStakedTotalTokens ?? "0").mul(nearPrice ?? 1))
   .plus(Big(lockupNearBalances?.totalParsed ?? "0").mul(nearPrice ?? 1))
   .plus(Big(userFTTokens?.totalCumulativeAmt ?? "0"))
   .toFixed(2);

--- a/playwright-tests/tests/dashboard/home-page.spec.js
+++ b/playwright-tests/tests/dashboard/home-page.spec.js
@@ -1,17 +1,66 @@
 import { expect } from "@playwright/test";
 import { test } from "../../util/test.js";
-
 import {
   mockNearBalances,
   mockRpcRequest,
   mockWithFTBalance,
 } from "../../util/rpcmock.js";
-import {
-  CurrentTimestampInNanoseconds,
-  TransferProposalData,
-} from "../../util/inventory.js";
 import { mockNearPrice } from "../../util/nearblocks.js";
 import { getInstanceConfig } from "../../util/config.js";
+
+const availableBalance = "1.00";
+const stakedBalance = "1.00";
+const storageBalance = "0.00";
+
+async function mockStakedPoolBalances({ page, daoAccount }) {
+  await page.route(
+    `https://api.fastnear.com/v1/account/${daoAccount}/staking`,
+    async (route) => {
+      const json = {
+        account_id: daoAccount,
+        pools: [
+          {
+            last_update_block_height: null,
+            pool_id: "here.poolv1.near",
+          },
+        ],
+      };
+
+      await route.fulfill({ json });
+    }
+  );
+
+  await page.route(
+    `https://archival-rpc.mainnet.fastnear.com/`,
+    async (route) => {
+      const request = await route.request();
+      const requestPostData = request.postDataJSON();
+
+      if (
+        requestPostData.params &&
+        requestPostData.params.request_type === "call_function" &&
+        requestPostData.params.method_name === "get_account_staked_balance"
+      ) {
+        const json = {
+          jsonrpc: "2.0",
+          result: {
+            block_hash: "GXEuJYXvoXoiDhtDJP8EiPXesQbQuwDSWadYzy2JAstV",
+            block_height: 132031112,
+            logs: [],
+            result: [
+              49, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+              48, 48, 48, 48, 48, 48, 48, 48, 48,
+            ],
+          },
+          id: "dontcare",
+        };
+        await route.fulfill({ json });
+      } else {
+        await route.continue();
+      }
+    }
+  );
+}
 
 test.afterEach(async ({ page }, testInfo) => {
   console.log(`Finished ${testInfo.title} with status ${testInfo.status}`);
@@ -27,25 +76,80 @@ test.describe("Dashboard Page", function () {
       await mockNearPrice({ daoAccount, nearPrice, page });
     }
 
-    await mockWithFTBalance({ page, daoAccount, isSufficient: true });
+    // fetch near balance
+    await mockNearBalances({
+      page,
+      accountId: daoAccount,
+      balance: BigInt(1 * 10 ** 24).toString(),
+      storage: 0,
+    });
+
+    // fetch near pool balance
+    await mockStakedPoolBalances({ page, daoAccount });
+
+    await mockWithFTBalance({
+      page,
+      daoAccount,
+      isSufficient: true,
+      isDashboard: true,
+    });
     await page.goto(`/${instanceAccount}/widget/app`);
     await expect(
       page.locator("div").filter({ hasText: /^Dashboard$/ })
     ).toBeVisible();
   });
-  test("Portfolio should correctly displays FT tokens", async ({ page }) => {
+
+  test("should correctly sort tokens by token price and quantity", async ({
+    page,
+  }) => {
     test.setTimeout(60_000);
-    await expect(page.getByText("USDt").first()).toBeVisible();
-    await expect(page.getByText("USDC").first()).toBeVisible();
+    await page.waitForTimeout(5_000);
+    await expect(page.getByText("BLACKDRAGON $0.00 743,919,574")).toBeVisible();
+    await expect(page.getByText("USDC $1.00 72.00")).toBeVisible();
+    await expect(page.getByText("REF $0.12 0.98")).toBeVisible();
+    await expect(page.getByText("SLUSH $0.00 7,231,110.99")).toBeVisible();
+    await expect(page.getByText("RNC $0.00 710,047.00")).toBeVisible();
+    await page.getByRole("button", { name: "Show more tokens " }).click();
+    await expect(
+      page.getByText("CHAINABSTRACT $0.00 1,000,000.00")
+    ).toBeVisible();
   });
 
-  test("Portfolio should correctly displays NEAR price", async ({ page }) => {
+  test("should correctly displays NEAR price", async ({ page }) => {
     test.setTimeout(60_000);
     await page.waitForTimeout(5_000);
     const nearPriceElements = await page
       .locator(`text=$${nearPrice}.00`)
       .count();
     expect(nearPriceElements).toBeGreaterThan(0);
+  });
+
+  test("should correctly display NEAR tokens segregation ", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    await page.waitForTimeout(5_000);
+    await page.locator("div:nth-child(2) > .bi").first().click();
+    await expect(
+      page.getByText(`Available Balance ${availableBalance} `)
+    ).toBeVisible();
+    await expect(page.getByText(`Staking ${stakedBalance} `)).toBeVisible();
+    await expect(
+      page.getByText(`Reserved for storage ${storageBalance} `)
+    ).toBeVisible();
+  });
+
+  test("should correctly display total balance", async ({
+    page,
+    daoAccount,
+  }) => {
+    test.setTimeout(60_000);
+    // will add new tests for lockup in next PR
+    if (daoAccount === "infinex.sputnik-dao.near") {
+      return;
+    }
+    // totalcummulative is $10 (of FTs as per mocked API) and 2N is $10
+    await expect(page.getByText("Total Balance $20.00 USD")).toBeVisible();
   });
 
   test("Should see 404 modal", async ({ page }) => {

--- a/playwright-tests/util/rpcmock.js
+++ b/playwright-tests/util/rpcmock.js
@@ -368,7 +368,12 @@ export async function mockNearBalances({ page, accountId, balance, storage }) {
   );
 }
 
-export async function mockWithFTBalance({ page, daoAccount, isSufficient }) {
+export async function mockWithFTBalance({
+  page,
+  daoAccount,
+  isSufficient,
+  isDashboard,
+}) {
   await page.route(
     (daoAccount.includes("testing")
       ? `https://ref-sdk-test-cold-haze-1300.fly.dev`
@@ -378,33 +383,135 @@ export async function mockWithFTBalance({ page, daoAccount, isSufficient }) {
       await route.fulfill({
         json: {
           totalCumulativeAmt: 10,
-          fts: [
-            {
-              contract: "usdt.tether-token.near",
-              amount: "4500000",
-              ft_meta: {
-                name: "Tether USD",
-                symbol: "USDt",
-                decimals: 6,
-                icon: "data:image/svg+xml,%3Csvg width='111' height='90' viewBox='0 0 111 90' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M24.4825 0.862305H88.0496C89.5663 0.862305 90.9675 1.64827 91.7239 2.92338L110.244 34.1419C111.204 35.7609 110.919 37.8043 109.549 39.1171L58.5729 87.9703C56.9216 89.5528 54.2652 89.5528 52.6139 87.9703L1.70699 39.1831C0.305262 37.8398 0.0427812 35.7367 1.07354 34.1077L20.8696 2.82322C21.6406 1.60483 23.0087 0.862305 24.4825 0.862305ZM79.8419 14.8003V23.5597H61.7343V29.6329C74.4518 30.2819 83.9934 32.9475 84.0642 36.1425L84.0638 42.803C83.993 45.998 74.4518 48.6635 61.7343 49.3125V64.2168H49.7105V49.3125C36.9929 48.6635 27.4513 45.998 27.3805 42.803L27.381 36.1425C27.4517 32.9475 36.9929 30.2819 49.7105 29.6329V23.5597H31.6028V14.8003H79.8419ZM55.7224 44.7367C69.2943 44.7367 80.6382 42.4827 83.4143 39.4727C81.0601 36.9202 72.5448 34.9114 61.7343 34.3597V40.7183C59.7966 40.8172 57.7852 40.8693 55.7224 40.8693C53.6595 40.8693 51.6481 40.8172 49.7105 40.7183V34.3597C38.8999 34.9114 30.3846 36.9202 28.0304 39.4727C30.8066 42.4827 42.1504 44.7367 55.7224 44.7367Z' fill='%23009393'/%3E%3C/svg%3E",
-                reference: null,
-                price: 1,
-              },
-            },
-            {
-              contract:
-                "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1",
-              amount: isSufficient ? "1500000" : "10",
-              ft_meta: {
-                name: "USDC",
-                symbol: "USDC",
-                decimals: 6,
-                icon: "",
-                reference: null,
-                price: 1,
-              },
-            },
-          ],
+          fts: isDashboard
+            ? [
+                {
+                  contract: "crans.tkn.near",
+                  amount: "30000000000000000000000000000",
+                  ft_meta: {
+                    name: "Crans",
+                    symbol: "CRANS",
+                    decimals: 24,
+                    icon: "",
+                    reference: null,
+                    price: null,
+                  },
+                },
+                {
+                  contract: "slush.tkn.near",
+                  amount: "7231110994833791657750514",
+                  ft_meta: {
+                    name: "Slushie",
+                    symbol: "SLUSH",
+                    decimals: 18,
+                    icon: "",
+                    reference: null,
+                    price: null,
+                  },
+                },
+                {
+                  contract: "chainabstract.tkn.near",
+                  amount: "1000000000000000000000000",
+                  ft_meta: {
+                    name: "Chain Abstraction",
+                    symbol: "CHAINABSTRACT",
+                    decimals: 18,
+                    icon: "",
+                    reference: null,
+                    price: null,
+                  },
+                },
+                {
+                  contract: "rnc.tkn.near",
+                  amount: "710047000000000000000000",
+                  ft_meta: {
+                    name: "Republican National Committee ",
+                    symbol: "RNC",
+                    decimals: 18,
+                    icon: "",
+                    reference: null,
+                    price: null,
+                  },
+                },
+                {
+                  contract: "hoot-657.meme-cooking.near",
+                  amount: "1000000000000000000000",
+                  ft_meta: {
+                    name: "HOOT",
+                    symbol: "HOOT",
+                    decimals: 18,
+                    icon: "",
+                    reference: null,
+                    price: null,
+                  },
+                },
+
+                {
+                  contract:
+                    "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1",
+                  amount: "72000000",
+                  ft_meta: {
+                    name: "USDC",
+                    symbol: "USDC",
+                    decimals: 6,
+                    icon: "",
+                    reference: null,
+                    price: 0.999997,
+                  },
+                },
+                {
+                  contract: "token.v2.ref-finance.near",
+                  amount: "977826758655654840",
+                  ft_meta: {
+                    name: "Ref Finance Token",
+                    symbol: "REF",
+                    decimals: 18,
+                    icon: "",
+                    reference: null,
+                    price: 0.123989,
+                  },
+                },
+
+                {
+                  contract: "blackdragon.tkn.near",
+                  amount: "743919574977600000000000000000000000",
+                  ft_meta: {
+                    name: "Black Dragon",
+                    symbol: "BLACKDRAGON",
+                    decimals: 24,
+                    icon: "",
+                    reference: null,
+                    price: 3e-8,
+                  },
+                },
+              ]
+            : [
+                {
+                  contract: "usdt.tether-token.near",
+                  amount: "4500000",
+                  ft_meta: {
+                    name: "Tether USD",
+                    symbol: "USDt",
+                    decimals: 6,
+                    icon: "",
+                    reference: null,
+                    price: 1,
+                  },
+                },
+                {
+                  contract:
+                    "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1",
+                  amount: isSufficient ? "1500000" : "10",
+                  ft_meta: {
+                    name: "USDC",
+                    symbol: "USDC",
+                    decimals: 6,
+                    icon: "",
+                    reference: null,
+                    price: 1,
+                  },
+                },
+              ],
           nfts: [],
         },
       });


### PR DESCRIPTION
Fastnear account API `https://api3.nearblocks.io/v1/account/shitzu.sputnik-dao.near` balance doesn't includes the staked amount, which the frontend did, so made some changes to add the staked tokens on top of the balance received from the API.
Updated backend API to show the [staked balance in chart](https://github.com/NEAR-DevHub/ref-sdk-api/pull/10)
[video.webm](https://github.com/user-attachments/assets/9fa92abe-d380-43b0-a5ee-ca6208094d30)
[video.webm](https://github.com/user-attachments/assets/267ac9b5-4a7b-4838-8821-03737de911fd)
[video.webm](https://github.com/user-attachments/assets/c0c619e2-daa1-4d4d-b9cb-2aac217db536)
