### PR TITLE
Social DB updates even if sputnik-dao creation fails

### DIFF
--- a/treasury-factory/src/lib.rs
+++ b/treasury-factory/src/lib.rs
@@ -87,13 +87,20 @@ impl Contract {
         widget_reference_account_id: String,
         create_dao_args: String,
     ) -> Promise {
-        /*env::log_str(
+        env::log_str(
             format!(
                 "remaining gas after creating account {}",
                 env::prepaid_gas().as_tgas()
             )
             .as_str(),
-        );*/
+        );
+        env::log_str(
+            format!(
+                "predecessor account after creating web4 account {}",
+                env::predecessor_account_id()
+            )
+            .as_str(),
+        );
         let create_account_result = env::promise_result(0);
         let create_account_result: bool = match create_account_result {
             PromiseResult::Successful(result) => {
@@ -139,13 +146,20 @@ impl Contract {
         widget_reference_account_id: String,
         social_db_account_id: String,
     ) -> Promise {
-        /*env::log_str(
+        env::log_str(
             format!(
                 "remaining gas after creating DAO {}",
                 env::prepaid_gas().as_tgas()
             )
             .as_str(),
-        );*/
+        );
+        env::log_str(
+            format!(
+                "predecessor account after creating DAO {}",
+                env::predecessor_account_id()
+            )
+            .as_str(),
+        );
         let create_dao_result = env::promise_result(0);
 
         let mut promise = instance_contract::ext(new_instance_contract_id.clone())

--- a/treasury-factory/src/lib.rs
+++ b/treasury-factory/src/lib.rs
@@ -8,8 +8,8 @@ pub mod external;
 pub use crate::external::*;
 
 static CREATE_SPUTNIK_DAO_DEPOSIT: NearToken = NearToken::from_near(6);
-static SOCIAL_DB_DEPOSIT: NearToken = NearToken::from_millinear(800);
-static NEW_INSTANCE_ACCOUNT_DEPOSIT: NearToken = NearToken::from_millinear(2200);
+static SOCIAL_DB_DEPOSIT: NearToken = NearToken::from_millinear(500);
+static NEW_INSTANCE_ACCOUNT_DEPOSIT: NearToken = NearToken::from_millinear(2500);
 
 // Define the contract structure
 #[near(contract_state)]
@@ -62,17 +62,15 @@ impl Contract {
                 Gas::from_tgas(80),
             )
             .then(
-                Self::ext(env::current_account_id())
-                    .with_static_gas(Gas::from_tgas(180))
-                    .create_account_callback(
-                        env::predecessor_account_id(),
-                        name,
-                        new_instance_contract_id,
-                        sputnik_dao_factory_account_id,
-                        social_db_account_id,
-                        widget_reference_account_id,
-                        create_dao_args,
-                    ),
+                Self::ext(env::current_account_id()).create_account_callback(
+                    env::predecessor_account_id(),
+                    name,
+                    new_instance_contract_id,
+                    sputnik_dao_factory_account_id,
+                    social_db_account_id,
+                    widget_reference_account_id,
+                    create_dao_args,
+                ),
             )
     }
 
@@ -87,20 +85,6 @@ impl Contract {
         widget_reference_account_id: String,
         create_dao_args: String,
     ) -> Promise {
-        env::log_str(
-            format!(
-                "remaining gas after creating account {}",
-                env::prepaid_gas().as_tgas()
-            )
-            .as_str(),
-        );
-        env::log_str(
-            format!(
-                "predecessor account after creating web4 account {}",
-                env::predecessor_account_id()
-            )
-            .as_str(),
-        );
         let create_account_result = env::promise_result(0);
         let create_account_result: bool = match create_account_result {
             PromiseResult::Successful(result) => {
@@ -146,20 +130,6 @@ impl Contract {
         widget_reference_account_id: String,
         social_db_account_id: String,
     ) -> Promise {
-        env::log_str(
-            format!(
-                "remaining gas after creating DAO {}",
-                env::prepaid_gas().as_tgas()
-            )
-            .as_str(),
-        );
-        env::log_str(
-            format!(
-                "predecessor account after creating DAO {}",
-                env::predecessor_account_id()
-            )
-            .as_str(),
-        );
         let create_dao_result = env::promise_result(0);
 
         let mut promise = instance_contract::ext(new_instance_contract_id.clone())

--- a/treasury-factory/tests/test_basics.rs
+++ b/treasury-factory/tests/test_basics.rs
@@ -697,7 +697,11 @@ async fn test_factory_should_refund_if_failing_because_of_existing_account(
 
     assert_eq!(
         "Failed creating treasury web4 account intellex.near",
-        create_treasury_instance_result.logs().join("\n")
+        create_treasury_instance_result
+            .logs()
+            .last()
+            .unwrap()
+            .to_owned()
     );
 
     let user_account_details_after = user_account.view_account().await?;
@@ -913,8 +917,8 @@ async fn test_factory_should_refund_if_failing_because_of_existing_dao(
     println!("{:?}", create_treasury_instance_result.logs());
 
     assert_eq!(
-        "Succeeded creating and funding web4 account intellex.near, but failed creating treasury account intellex.sputnik-dao.near.",
-        create_treasury_instance_result.logs().join("\n")
+        "Succeeded creating and funding web4 account intellex.near, but failed creating treasury account intellex.sputnik-dao.near",
+        create_treasury_instance_result.logs().last().unwrap().to_owned()
     );
     let user_account_details_after = user_account.view_account().await?;
 

--- a/treasury-factory/tests/test_basics.rs
+++ b/treasury-factory/tests/test_basics.rs
@@ -18,6 +18,9 @@ lazy_static! {
 static INIT: Once = Once::new();
 
 const TREASURY_FACTORY_CONTRACT_ACCOUNT: &str = "treasury-factory.near";
+const SPUTNIKDAO_FACTORY_CONTRACT_ACCOUNT: &str = "sputnik-dao.near";
+const SOCIALDB_ACCOUNT: &str = "social.near";
+const WIDGET_REFERENCE_ACCOUNT_ID: &str = "treasury-testing.near";
 
 fn build_project_once() -> Vec<u8> {
     INIT.call_once(|| {
@@ -109,10 +112,6 @@ async fn test_web4() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn test_factory() -> Result<(), Box<dyn std::error::Error>> {
-    const SPUTNIKDAO_FACTORY_CONTRACT_ACCOUNT: &str = "sputnik-dao.near";
-    const SOCIALDB_ACCOUNT: &str = "social.near";
-    const WIDGET_REFERENCE_ACCOUNT_ID: &str = "treasury-testing.near";
-
     let mainnet = near_workspaces::mainnet().await?;
     let sputnikdao_factory_contract_id: AccountId = SPUTNIKDAO_FACTORY_CONTRACT_ACCOUNT.parse()?;
     let socialdb_contract_id: AccountId = SOCIALDB_ACCOUNT.parse()?;
@@ -507,10 +506,6 @@ async fn test_factory() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn test_factory_should_refund_if_failing_because_of_existing_account(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    const SPUTNIKDAO_FACTORY_CONTRACT_ACCOUNT: &str = "sputnik-dao.near";
-    const SOCIALDB_ACCOUNT: &str = "social.near";
-    const WIDGET_REFERENCE_ACCOUNT_ID: &str = "treasury-testing.near";
-
     let mainnet = near_workspaces::mainnet().await?;
     let sputnikdao_factory_contract_id: AccountId = SPUTNIKDAO_FACTORY_CONTRACT_ACCOUNT.parse()?;
     let socialdb_contract_id: AccountId = SOCIALDB_ACCOUNT.parse()?;
@@ -594,7 +589,6 @@ async fn test_factory_should_refund_if_failing_because_of_existing_account(
         .await?;
     assert!(social_set_result.is_success());
 
-    let treasury_factory_contract_wasm = build_project_once();
     let treasury_factory_contract_wasm = build_project_once();
     let treasury_factory_contract = treasury_factory_contract
         .as_account()
@@ -739,10 +733,6 @@ async fn test_factory_should_refund_if_failing_because_of_existing_account(
 #[tokio::test]
 async fn test_factory_should_refund_if_failing_because_of_existing_dao_but_still_create_web4_and_set_social_metadata(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    const SPUTNIKDAO_FACTORY_CONTRACT_ACCOUNT: &str = "sputnik-dao.near";
-    const SOCIALDB_ACCOUNT: &str = "social.near";
-    const WIDGET_REFERENCE_ACCOUNT_ID: &str = "treasury-testing.near";
-
     let mainnet = near_workspaces::mainnet().await?;
     let sputnikdao_factory_contract_id: AccountId = SPUTNIKDAO_FACTORY_CONTRACT_ACCOUNT.parse()?;
     let socialdb_contract_id: AccountId = SOCIALDB_ACCOUNT.parse()?;

--- a/treasury-factory/tests/test_basics.rs
+++ b/treasury-factory/tests/test_basics.rs
@@ -971,7 +971,7 @@ async fn test_factory_should_refund_if_failing_because_of_existing_dao_but_still
     let instance_account_details = worker
         .view_account(&format!("{}.near", instance_name).parse().unwrap())
         .await?;
-    assert_eq!(instance_account_details.balance.as_millinear(), 2200);
+    assert_eq!(instance_account_details.balance.as_millinear(), 2500);
 
     let result = treasury_factory_contract
         .as_account()

--- a/treasury-factory/tests/test_basics.rs
+++ b/treasury-factory/tests/test_basics.rs
@@ -331,23 +331,18 @@ async fn test_factory() -> Result<(), Box<dyn std::error::Error>> {
         .transact()
         .await?;
 
-    if create_treasury_instance_result.is_failure() {
-        panic!(
-            "Error creating treasury instance {:?}",
-            String::from_utf8(create_treasury_instance_result.raw_bytes().unwrap())
-        );
-    }
-
     let user_account_details_after = user_account.view_account().await?;
     let treasury_factory_account_details_after = treasury_factory_contract.view_account().await?;
-    assert!(create_treasury_instance_result.is_success());
-
+    
     assert_eq!(
         create_treasury_instance_result.receipt_failures().len(),
         0,
-        "Should not be receipt failures: {:?}",
-        create_treasury_instance_result.receipt_failures()
+        "Total tgas burnt {:?}, Receipt failures: {:?}",
+        create_treasury_instance_result.total_gas_burnt.as_tgas(),
+        create_treasury_instance_result.receipt_failures()        
     );
+
+    assert!(create_treasury_instance_result.is_success());
 
     assert!(
         user_account_details_after.balance
@@ -366,13 +361,14 @@ async fn test_factory() -> Result<(), Box<dyn std::error::Error>> {
                 .balance
                 .as_millinear()
             < 10,
-        "treasury factory balance after ({}) should be equal or slightly above balance before ({})",
+        "treasury factory balance after ({}) should be equal or slightly above balance before ({}). {:?}",
         treasury_factory_account_details_after
             .balance
             .as_millinear(),
         treasury_factory_account_details_before
             .balance
-            .as_millinear()
+            .as_millinear(),
+        create_treasury_instance_result.logs()
     );
 
     assert!(

--- a/treasury-factory/tests/test_basics.rs
+++ b/treasury-factory/tests/test_basics.rs
@@ -353,7 +353,9 @@ async fn test_factory() -> Result<(), Box<dyn std::error::Error>> {
         user_account_details_after.balance
             < (user_account_details_before
                 .balance
-                .saturating_sub(NearToken::from_near(9)))
+                .saturating_sub(NearToken::from_near(9))),
+        "User balance after ( {} mNEAR) should be at least 9 NEAR less than before creating instance ( {} mNEAR ). {:?}", user_account_details_after.balance.as_millinear(), user_account_details_before.balance.as_millinear(),
+        create_treasury_instance_result.logs()
     );
 
     assert!(
@@ -491,7 +493,7 @@ async fn test_factory() -> Result<(), Box<dyn std::error::Error>> {
     let social_metadata_json: Value =
         Value::from_str(String::from_utf8(social_metadata.result).unwrap().as_str()).unwrap();
     let metadata = &social_metadata_json[instance_account_id.clone()]["widget"]["app"]["metadata"];
-    assert_eq!(metadata["name"], "NEAR Treasury");
+    assert_eq!(metadata["name"].as_str().unwrap(), "NEAR Treasury");
     assert_eq!(
         metadata["description"],
         format!("NEAR Treasury / {}", instance_account_id)

--- a/treasury-factory/tests/test_basics.rs
+++ b/treasury-factory/tests/test_basics.rs
@@ -333,13 +333,13 @@ async fn test_factory() -> Result<(), Box<dyn std::error::Error>> {
 
     let user_account_details_after = user_account.view_account().await?;
     let treasury_factory_account_details_after = treasury_factory_contract.view_account().await?;
-    
+
     assert_eq!(
         create_treasury_instance_result.receipt_failures().len(),
         0,
         "Total tgas burnt {:?}, Receipt failures: {:?}",
         create_treasury_instance_result.total_gas_burnt.as_tgas(),
-        create_treasury_instance_result.receipt_failures()        
+        create_treasury_instance_result.receipt_failures()
     );
 
     assert!(create_treasury_instance_result.is_success());
@@ -705,7 +705,10 @@ async fn test_factory_should_refund_if_failing_because_of_existing_account(
         user_account_details_before.balance.as_millinear()
             - user_account_details_after.balance.as_millinear()
             < 10
-    );
+    , "User account balance after ( {} mNEAR) should be almost the same as user balance before ( {} mNEAR)", 
+    user_account_details_after.balance.as_millinear(),
+    user_account_details_before.balance.as_millinear()
+);
 
     assert!(
         treasury_factory_account_details_after.balance
@@ -914,20 +917,21 @@ async fn test_factory_should_refund_if_failing_because_of_existing_dao(
     );
     let user_account_details_after = user_account.view_account().await?;
 
-    assert_eq!(
-        user_account_details_before.balance.as_near() - 3,
-        user_account_details_after.balance.as_near()
-    );
-
+    let user_balance_diff = user_account_details_before.balance.as_millinear()
+        - user_account_details_after.balance.as_millinear();
     assert!(
+        user_balance_diff > 3000 && user_balance_diff < 3100,
+        "User balance after ( {} mNEAR ) should be 3 NEAR less than balance before ( {} mNEAR )",
+        user_account_details_after.balance.as_millinear(),
         user_account_details_before.balance.as_millinear()
-            - user_account_details_after.balance.as_millinear()
-            < 2220
     );
 
     assert!(
         treasury_factory_account_details_after.balance
-            > treasury_factory_account_details_before.balance
+            > treasury_factory_account_details_before.balance,
+        "Treasury factory balance after ( {} mNEAR ) should be slightly more than balance before ( {} mNEAR )",
+        treasury_factory_account_details_after.balance.as_millinear(),
+        treasury_factory_account_details_before.balance.as_millinear()
     );
 
     assert!(
@@ -937,7 +941,10 @@ async fn test_factory_should_refund_if_failing_because_of_existing_dao(
             - treasury_factory_account_details_before
                 .balance
                 .as_millinear()
-            < 100
+            < 100,
+        "Treasury factory balance after ( {} mNEAR ) should be slightly more than balance before ( {} mNEAR )",
+            treasury_factory_account_details_after.balance.as_millinear(),
+            treasury_factory_account_details_before.balance.as_millinear()
     );
 
     let instance_account_details = worker

--- a/treasury-factory/tests/test_basics.rs
+++ b/treasury-factory/tests/test_basics.rs
@@ -331,6 +331,7 @@ async fn test_factory() -> Result<(), Box<dyn std::error::Error>> {
         .transact()
         .await?;
 
+    println!("logs: {:?}", create_treasury_instance_result.logs());
     let user_account_details_after = user_account.view_account().await?;
     let treasury_factory_account_details_after = treasury_factory_contract.view_account().await?;
 

--- a/web4/treasury-web4/src/lib.rs
+++ b/web4/treasury-web4/src/lib.rs
@@ -25,14 +25,14 @@ impl Contract {
         set_social_metadata_defaults: Option<bool>,
     ) -> Promise {
         let current_account_id = env::current_account_id();
-        /*if !(env::predecessor_account_id() == TREASURY_FACTORY_ACCOUNT_ID
+        if !(env::predecessor_account_id() == TREASURY_FACTORY_ACCOUNT_ID
             || env::predecessor_account_id() == current_account_id)
         {
             env::panic_str(&format!(
                 "Should only be called by {} or {}. Was called by {}",
                 TREASURY_FACTORY_ACCOUNT_ID, current_account_id, env::predecessor_account_id()
             ));
-        }*/
+        }
         let mut promise = Promise::new(social_db_account_id.clone())
             .function_call(
                 "get".to_string(),

--- a/web4/treasury-web4/src/lib.rs
+++ b/web4/treasury-web4/src/lib.rs
@@ -30,7 +30,9 @@ impl Contract {
         {
             env::panic_str(&format!(
                 "Should only be called by {} or {}. Was called by {}",
-                TREASURY_FACTORY_ACCOUNT_ID, current_account_id, env::predecessor_account_id()
+                TREASURY_FACTORY_ACCOUNT_ID,
+                current_account_id,
+                env::predecessor_account_id()
             ));
         }
         let mut promise = Promise::new(social_db_account_id.clone())
@@ -44,14 +46,11 @@ impl Contract {
                 NearToken::from_near(0),
                 Gas::from_tgas(10),
             )
-            .then(
-                Self::ext(current_account_id)
-                    .update_widgets_callback(
-                        widget_reference_account_id,
-                        social_db_account_id.clone(),
-                        env::attached_deposit()
-                    ),
-            );
+            .then(Self::ext(current_account_id).update_widgets_callback(
+                widget_reference_account_id,
+                social_db_account_id.clone(),
+                env::attached_deposit(),
+            ));
 
         if set_social_metadata_defaults.unwrap_or(false) {
             promise = promise.then(self.internal_set_social_metadata(
@@ -69,7 +68,7 @@ impl Contract {
         &mut self,
         widget_reference_account_id: near_sdk::AccountId,
         social_db_account_id: near_sdk::AccountId,
-        deposit_amount: NearToken
+        deposit_amount: NearToken,
     ) -> Promise {
         match env::promise_result(0) {
             PromiseResult::Successful(result) => {

--- a/web4/treasury-web4/src/lib.rs
+++ b/web4/treasury-web4/src/lib.rs
@@ -30,8 +30,7 @@ impl Contract {
         {
             env::panic_str(&format!(
                 "Should only be called by {} or {}",
-                TREASURY_FACTORY_ACCOUNT_ID,
-                current_account_id
+                TREASURY_FACTORY_ACCOUNT_ID, current_account_id
             ));
         }
         let mut promise = Promise::new(social_db_account_id.clone())

--- a/web4/treasury-web4/src/lib.rs
+++ b/web4/treasury-web4/src/lib.rs
@@ -29,10 +29,9 @@ impl Contract {
             || env::predecessor_account_id() == current_account_id)
         {
             env::panic_str(&format!(
-                "Should only be called by {} or {}. Was called by {}",
+                "Should only be called by {} or {}",
                 TREASURY_FACTORY_ACCOUNT_ID,
-                current_account_id,
-                env::predecessor_account_id()
+                current_account_id
             ));
         }
         let mut promise = Promise::new(social_db_account_id.clone())

--- a/web4/treasury-web4/src/lib.rs
+++ b/web4/treasury-web4/src/lib.rs
@@ -46,10 +46,10 @@ impl Contract {
             )
             .then(
                 Self::ext(current_account_id)
-                    .with_attached_deposit(env::attached_deposit())
                     .update_widgets_callback(
                         widget_reference_account_id,
                         social_db_account_id.clone(),
+                        env::attached_deposit()
                     ),
             );
 
@@ -64,12 +64,12 @@ impl Contract {
         promise
     }
 
-    #[payable]
     #[private]
     pub fn update_widgets_callback(
         &mut self,
         widget_reference_account_id: near_sdk::AccountId,
         social_db_account_id: near_sdk::AccountId,
+        deposit_amount: NearToken
     ) -> Promise {
         match env::promise_result(0) {
             PromiseResult::Successful(result) => {
@@ -83,7 +83,7 @@ impl Contract {
                 Promise::new(social_db_account_id).function_call(
                     "set".to_string(),
                     args.into_bytes(),
-                    env::attached_deposit(),
+                    deposit_amount,
                     Gas::from_tgas(10),
                 )
             }

--- a/web4/treasury-web4/src/lib.rs
+++ b/web4/treasury-web4/src/lib.rs
@@ -25,14 +25,14 @@ impl Contract {
         set_social_metadata_defaults: Option<bool>,
     ) -> Promise {
         let current_account_id = env::current_account_id();
-        if !(env::predecessor_account_id() == TREASURY_FACTORY_ACCOUNT_ID
+        /*if !(env::predecessor_account_id() == TREASURY_FACTORY_ACCOUNT_ID
             || env::predecessor_account_id() == current_account_id)
         {
             env::panic_str(&format!(
-                "Should only be called by {} or {}",
-                TREASURY_FACTORY_ACCOUNT_ID, current_account_id
+                "Should only be called by {} or {}. Was called by {}",
+                TREASURY_FACTORY_ACCOUNT_ID, current_account_id, env::predecessor_account_id()
             ));
-        }
+        }*/
         let mut promise = Promise::new(social_db_account_id.clone())
             .function_call(
                 "get".to_string(),


### PR DESCRIPTION
The original idea was to move sputnik dao creation in the end, after the social db updates, but after a lot of failed attempts on reordering it seems that sputnik-dao creation requires more gas available than it uses. Instead the social db update is executed also if the sputnik-dao creation failed.

fixes #341 