### PR TITLE
Fixed handling of 'all' group

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/pages/payments/History.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/History.jsx
@@ -69,7 +69,8 @@ const policy = treasuryDaoID
 
 const transferApproversGroup = getApproversAndThreshold(
   treasuryDaoID,
-  "transfer"
+  "transfer",
+  context.accountId
 );
 
 return (

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/PendingRequests.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/PendingRequests.jsx
@@ -64,10 +64,16 @@ const policy = treasuryDaoID
 
 const transferApproversGroup = getApproversAndThreshold(
   treasuryDaoID,
-  "transfer"
+  "transfer",
+  context.accountId
 );
 
-const deleteGroup = getApproversAndThreshold(treasuryDaoID, "transfer", true);
+const deleteGroup = getApproversAndThreshold(
+  treasuryDaoID,
+  "transfer",
+  context.accountId,
+  true
+);
 
 return (
   <div className="d-flex flex-column flex-1 justify-content-between">

--- a/instances/widgets.treasury-factory.near/widget/pages/proposals-feed/History.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/proposals-feed/History.jsx
@@ -69,7 +69,8 @@ const policy = treasuryDaoID
 
 const transferApproversGroup = getApproversAndThreshold(
   treasuryDaoID,
-  "transfer"
+  "transfer",
+  context.accountId
 );
 
 return (

--- a/instances/widgets.treasury-factory.near/widget/pages/proposals-feed/PendingRequests.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/proposals-feed/PendingRequests.jsx
@@ -51,10 +51,16 @@ const policy = treasuryDaoID
 
 const transferApproversGroup = getApproversAndThreshold(
   treasuryDaoID,
-  "transfer"
+  "transfer",
+  context.accountId
 );
 
-const deleteGroup = getApproversAndThreshold(treasuryDaoID, "transfer", true);
+const deleteGroup = getApproversAndThreshold(
+  treasuryDaoID,
+  "transfer",
+  context.accountId,
+  true
+);
 
 return (
   <div className="d-flex flex-column flex-1 justify-content-between">

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/Theme.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/Theme.jsx
@@ -24,7 +24,7 @@ const { treasuryDaoID, themeColor } = VM.require(
 const hasCreatePermission = hasPermission(
   treasuryDaoID,
   context.accountId,
-  "policy",
+  "config",
   "AddProposal"
 );
 

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/feed/History.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/feed/History.jsx
@@ -78,7 +78,11 @@ const policy = treasuryDaoID
   ? Near.view(treasuryDaoID, "get_policy", {})
   : null;
 
-const settingsApproverGroup = getApproversAndThreshold(treasuryDaoID, "policy");
+const settingsApproverGroup = getApproversAndThreshold(
+  treasuryDaoID,
+  "policy",
+  context.accountId
+);
 
 return (
   <div className="d-flex flex-column flex-1 justify-content-between">

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/feed/PendingRequests.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/feed/PendingRequests.jsx
@@ -58,9 +58,18 @@ const policy = treasuryDaoID
   ? Near.view(treasuryDaoID, "get_policy", {})
   : null;
 
-const settingsApproverGroup = getApproversAndThreshold(treasuryDaoID, "policy");
+const settingsApproverGroup = getApproversAndThreshold(
+  treasuryDaoID,
+  "policy",
+  context.accountId
+);
 
-const deleteGroup = getApproversAndThreshold(treasuryDaoID, "transfer", true);
+const deleteGroup = getApproversAndThreshold(
+  treasuryDaoID,
+  "transfer",
+  context.accountId,
+  true
+);
 
 return (
   <div className="d-flex flex-column flex-1 justify-content-between">

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/History.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/History.jsx
@@ -70,7 +70,8 @@ const policy = treasuryDaoID
 
 const functionCallApproversGroup = getApproversAndThreshold(
   treasuryDaoID,
-  "call"
+  "call",
+  context.accountId
 );
 
 return (

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/PendingRequests.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/PendingRequests.jsx
@@ -76,10 +76,16 @@ const policy = treasuryDaoID
 
 const functionCallApproversGroup = getApproversAndThreshold(
   treasuryDaoID,
-  "call"
+  "call",
+  context.accountId
 );
 
-const deleteGroup = getApproversAndThreshold(treasuryDaoID, "call", true);
+const deleteGroup = getApproversAndThreshold(
+  treasuryDaoID,
+  "call",
+  context.accountId,
+  true
+);
 
 return (
   <div className="d-flex flex-column flex-1 justify-content-between">

--- a/playwright-tests/storage-states/wallet-connected-admin-with-all-role.json
+++ b/playwright-tests/storage-states/wallet-connected-admin-with-all-role.json
@@ -1,0 +1,23 @@
+{
+  "cookies": [],
+  "origins": [
+    {
+      "origin": "http://localhost:8080",
+      "localStorage": [
+        {
+          "name": "near-wallet-selector:selectedWalletId",
+          "value": "\"my-near-wallet\""
+        },
+        {
+          "name": "near_app_wallet_auth_key",
+          "value": "{\"accountId\":\"all.near\",\"allKeys\":[\"ed25519:CziSGowWUKiP5N5pqGUgXCJXtqpySAk29YAU6zEs5RAi\"]}"
+        },
+        {
+          "name": "near-social-vm:v01::accountId:",
+          "value": "all.near"
+        }
+      ]
+    }
+  ],
+  "sessionStorage": []
+}

--- a/playwright-tests/tests/stake-delegation/stake-delegation.spec.js
+++ b/playwright-tests/tests/stake-delegation/stake-delegation.spec.js
@@ -619,12 +619,11 @@ test.describe("Have valid staked requests and sufficient token balance", functio
 
         test("should only allow authorized users to see 'Create Request' action", async ({
           page,
-          instanceAccount,
         }) => {
           test.setTimeout(60_000);
           await expect(page.getByText("Pending Requests")).toBeVisible();
-          const createRequestButton = page.getByRole("button", {
-            name: "Create Request",
+          const createRequestButton = page.getByText("Create Request", {
+            exact: true,
           });
 
           if (hasAllRole) {

--- a/playwright-tests/util/rpcmock.js
+++ b/playwright-tests/util/rpcmock.js
@@ -323,6 +323,7 @@ export async function updateDaoPolicyMembers({
   page,
   isMultiVote = false,
   isDefaultPolicy = false,
+  hasAllRole = false,
 }) {
   await mockRpcRequest({
     page,
@@ -342,6 +343,30 @@ export async function updateDaoPolicyMembers({
       originalResult = instanceAccount.includes("testing")
         ? getNewPolicy(votePolicy, votePolicy, votePolicy)
         : getOldPolicy(votePolicy, votePolicy, votePolicy);
+      if (hasAllRole) {
+        originalResult.roles.push({
+          name: "all",
+          kind: "Everyone",
+          permissions: [
+            "call:AddProposal",
+            "transfer:AddProposal",
+            "call:VoteRemove",
+            "transfer:VoteRemove",
+            "call:VoteReject",
+            "call:VoteApprove",
+            "call:RemoveProposal",
+            "call:Finalize",
+            "transfer:VoteReject",
+            "transfer:VoteApprove",
+            "transfer:RemoveProposal",
+            "transfer:Finalize",
+            "config:*",
+            "policy:*",
+            "policy_update_parameters:*",
+          ],
+          vote_policy: {},
+        });
+      }
       return originalResult;
     },
   });


### PR DESCRIPTION
Sputnik dao offers [everyone](https://github.com/near-daos/sputnik-dao-contract/blob/3d568f9517a8c7a6510786d978bb25b180501841/sputnikdao2/src/policy.rs#L17) role, and some existing dao (created w/o self flow) have this role as part of their policy, so added handling of this role, as it has different kind (doesn't have a group of people as members), also added tests for each page to check everything works as expected