### PR TITLE
fix treasury-factory package.repository/asset exchange test

### DIFF
--- a/playwright-tests/tests/asset-exchange/create-exchange-request.spec.js
+++ b/playwright-tests/tests/asset-exchange/create-exchange-request.spec.js
@@ -24,6 +24,11 @@ async function mockSwapResponse({ page, response, daoAccount }) {
   );
 }
 
+test.afterEach(async ({ page }, testInfo) => {
+  console.log(`Finished ${testInfo.title} with status ${testInfo.status}`);
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+});
+
 test.describe("User is not logged in", function () {
   test("should not see 'Create Request' action", async ({
     page,
@@ -185,7 +190,7 @@ test.describe("User is logged in", function () {
       page.getByText(
         "Hey Ori, you don't have enough NEAR to complete actions on your treasury."
       )
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
     await page.waitForTimeout(1_000);
     await page
       .getByRole("button", {

--- a/treasury-factory/Cargo.toml
+++ b/treasury-factory/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # TODO: Fill out the repository field to help NEAR ecosystem tools to discover your project.
 # NEP-0330 is automatically implemented for all contracts built with https://github.com/near/cargo-near.
 # Link to the repository will be available via `contract_source_metadata` view-function.
-repository = "https://github.com/<xxx>/<xxx>"
+repository = "https://github.com/NEAR-DevHub/neardevhub-treasury-dashboard"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
- set the correct repository URL in  `package.repository` to Treasury Factory `Cargo.toml` because of failed workflow: https://github.com/NEAR-DevHub/neardevhub-treasury-dashboard/actions/runs/13767483722/job/38497488699
- add `page.unrouteAll` to asset exchange create-exchange-request test to avoid tests failing because of this.
