### PR TITLE
Fix 404 page error for lockup

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/components/templates/AppLayout.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/templates/AppLayout.jsx
@@ -433,6 +433,14 @@ function AppLayout({ page, instance, children, treasuryDaoID, accountId }) {
       `}
   `;
 
+  if (page === "lockup") {
+    children = (
+      <Widget
+        src={"${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/pages.lockup.index"}
+        props={{ page, instance }}
+      />
+    );
+  }
   return (
     <ParentContainer data-bs-theme={isDarkTheme ? "dark" : "light"}>
       <Theme

--- a/instances/widgets.treasury-factory.near/widget/pages/lockup/Table.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/lockup/Table.jsx
@@ -1,5 +1,5 @@
 const accountId = context.accountId;
-const transferApproversGroup = props.transferApproversGroup;
+const functionCallApproversGroup = props.functionCallApproversGroup;
 const deleteGroup = props.deleteGroup;
 const instance = props.instance;
 const policy = props.policy;
@@ -41,7 +41,7 @@ const columnsVisibility = JSON.parse(
 const [showToastStatus, setToastStatus] = useState(false);
 const [voteProposalId, setVoteProposalId] = useState(null);
 const hasVotingPermission = (
-  transferApproversGroup?.approverAccounts ?? []
+  functionCallApproversGroup?.approverAccounts ?? []
 ).includes(accountId);
 const hasDeletePermission = (deleteGroup?.approverAccounts ?? []).includes(
   accountId
@@ -153,9 +153,9 @@ const columns = [
   { title: "Allow Cancellation", show: allowLockupCancellation },
   { title: "Allow Staking", show: true },
   { title: "Required Votes", show: true },
-  { title: "Votes", show: isPendingRequests },
+  { title: "Votes", show: isPendingRequests, className: "text-center" },
   { title: "Approvers", show: true },
-  { title: "Actions", show: isPendingRequests },
+  { title: "Actions", show: isPendingRequests, className: "text-right" },
 ];
 
 function isVisible(column) {
@@ -165,7 +165,7 @@ function isVisible(column) {
     : "display-none";
 }
 
-const requiredVotes = transferApproversGroup?.requiredVotes;
+const requiredVotes = functionCallApproversGroup?.requiredVotes;
 
 const ToastStatusContent = () => {
   let content = "";
@@ -355,7 +355,7 @@ const ProposalsComponent = ({ item }) => {
         />
       </td>
       {isPendingRequests && (hasVotingPermission || hasDeletePermission) && (
-        <td className={isVisible("Actions") + " text-center"}>
+        <td className={isVisible("Actions") + " text-right"}>
           <Widget
             src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.VoteActions`}
             props={{

--- a/playwright-tests/tests/lockup/create-lockup.spec.js
+++ b/playwright-tests/tests/lockup/create-lockup.spec.js
@@ -26,6 +26,7 @@ async function clickCreateLockupRequestButton(page) {
 }
 
 async function gotoForm(page, instanceAccount) {
+  await page.waitForTimeout(6_000);
   await page.goto(`/${instanceAccount}/widget/app?page=lockup`);
   await clickCreateLockupRequestButton(page);
 }
@@ -134,7 +135,7 @@ test.describe.parallel("User logged in with different roles", () => {
       test(`should ${
         canCreateRequest ? "see" : "not see"
       } 'Create Request' action`, async ({ page, instanceAccount }) => {
-        test.setTimeout(60_000);
+        test.setTimeout(100_000);
 
         await updateDaoPolicyMembers({
           instanceAccount,
@@ -172,7 +173,7 @@ test.describe("User is logged in", function () {
     instanceAccount,
     daoAccount,
   }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(100_000);
     await mockNearBalances({
       page,
       accountId: daoAccount,
@@ -193,7 +194,7 @@ test.describe("User is logged in", function () {
     page,
     instanceAccount,
   }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(100_000);
     await updateDaoPolicyMembers({ instanceAccount, page });
     await gotoForm(page, instanceAccount);
 
@@ -212,7 +213,7 @@ test.describe("User is logged in", function () {
     instanceAccount,
     daoAccount,
   }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(100_000);
     await mockPikespeakFTTokensResponse({ page, daoAccount });
     await updateDaoPolicyMembers({ instanceAccount, page });
     await gotoForm(page, instanceAccount);
@@ -244,8 +245,7 @@ test.describe("User is logged in", function () {
     instanceAccount,
     daoAccount,
   }) => {
-    test.setTimeout(60_000);
-
+    test.setTimeout(100_000);
     await mockPikespeakFTTokensResponse({ page, daoAccount });
     await updateDaoPolicyMembers({ instanceAccount, page });
     await mockInventory({ page, account: daoAccount });
@@ -281,7 +281,7 @@ test.describe("User is logged in", function () {
       instanceAccount,
       daoAccount,
     }) => {
-      test.setTimeout(60_000);
+      test.setTimeout(100_000);
       await mockPikespeakFTTokensResponse({ page, daoAccount });
       await updateDaoPolicyMembers({ instanceAccount, page });
       await mockInventory({ page, account: daoAccount });
@@ -345,8 +345,7 @@ test.describe("User is logged in", function () {
       daoAccount,
     }) => {
       const receiverAccount = "webassemblymusic.near";
-
-      test.setTimeout(60_000);
+      test.setTimeout(100_000);
       await mockPikespeakFTTokensResponse({ page, daoAccount });
       await updateDaoPolicyMembers({ instanceAccount, page });
       await mockInventory({ page, account: daoAccount });
@@ -418,7 +417,7 @@ test.describe("User is logged in", function () {
     });
 
     test.beforeEach(async ({ page, daoAccount, instanceAccount }) => {
-      test.setTimeout(60_000);
+      test.setTimeout(100_000);
       await mockPikespeakFTTokensResponse({ page, daoAccount });
       await updateDaoPolicyMembers({ instanceAccount, page });
       await mockInventory({ page, account: daoAccount });


### PR DESCRIPTION
We can't directly modify the `app.jsx` file for instances created through the self-flow, as access remains with the creator. While we do have access via one of our keys, updating it for all instances would be challenging.  

As a quick fix, I’ve made a change in the Navbar—when the page is `lockup`, it renders the component instead of the passed children.  

@petersalomonsen, just flagging this as part of the system upgrade. Ideally, users should update their widgets to support the new tabs.