### PR TITLE
Fix multi vote check

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/components/VoteActions.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/VoteActions.jsx
@@ -141,7 +141,13 @@ useEffect(() => {
     const checkForVoteOnProposal = () => {
       getProposalData()
         .then((proposal) => {
-          if (JSON.stringify(proposal.votes) !== JSON.stringify(votes)) {
+          const sortedProposalVotes = JSON.stringify(
+            Object.keys(proposal?.votes ?? {}).sort()
+          );
+          const sortedVotes = JSON.stringify(Object.keys(votes ?? {}).sort());
+          if (
+            JSON.stringify(sortedProposalVotes) !== JSON.stringify(sortedVotes)
+          ) {
             checkProposalStatus();
             clearTimeout(checkTxnTimeout);
             setTxnCreated(false);

--- a/playwright-tests/tests/payments/vote-on-request.spec.js
+++ b/playwright-tests/tests/payments/vote-on-request.spec.js
@@ -42,6 +42,13 @@ async function voteOnProposal({
       } else {
         originalResult.status = "InProgress";
       }
+      if (isMultiVote && !isTransactionCompleted) {
+        originalResult.votes = {
+          "mugen2_ipf1.near": "Approve",
+          "kmao.near": "Approve",
+          "zorsub.near": "Approve",
+        };
+      }
       return originalResult;
     },
   });
@@ -53,6 +60,14 @@ async function voteOnProposal({
     },
     modifyOriginalResultFunction: (originalResult) => {
       originalResult = transferProposalData;
+      // have multiple votes in, to check for order
+      if (isMultiVote && !isTransactionCompleted) {
+        originalResult.votes = {
+          "kmao.near": "Approve",
+          "mugen2_ipf1.near": "Approve",
+          "zorsub.near": "Approve",
+        };
+      }
       if (isTransactionCompleted && vote === "Remove" && !isMultiVote) {
         return {
           isError: true,


### PR DESCRIPTION
Infinex encountered an issue where clicking on any vote action caused the page to re-render, preventing users from seeing the BOS confirmation modal to review and sign the transaction. This happened because the order of votes changed, leading the UI to mistakenly assume a new vote was cast.  

To fix this, instead of directly comparing vote objects, I now compare their keys after sorting them. This ensures the UI correctly detects actual changes rather than just differences in order.