### PR TITLE
Hide wallet dropdown in stake delegation when staking is disabled

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/components/WalletDropdown.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/WalletDropdown.jsx
@@ -1,20 +1,25 @@
-const { getNearBalances, accountToLockup } = VM.require(
-  "${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/lib.common"
-) || { getNearBalances: () => {} };
+const { getNearBalances, accountToLockup, deserializeLockupContract } =
+  VM.require("${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/lib.common") || {
+    getNearBalances: () => {},
+  };
 
 const lockupNearBalances = props.lockupNearBalances;
 const instance = props.instance;
 const selectedValue = props.selectedValue;
 const onUpdate = props.onUpdate;
 
-if (!instance || typeof accountToLockup !== "function") {
+if (
+  !instance ||
+  typeof accountToLockup !== "function" ||
+  typeof deserializeLockupContract !== "function"
+) {
   return <></>;
 }
 
 const { treasuryDaoID } = VM.require(`${instance}/widget/config.data`);
 const lockupContract = accountToLockup(treasuryDaoID);
-
 const nearBalances = getNearBalances(treasuryDaoID);
+const [isLockupStakingAllowed, setLockupStakingAllowed] = useState(false);
 
 const nearPrice = useCache(
   () =>
@@ -43,6 +48,37 @@ const [walletOptions, setWalletOptions] = useState([
     balance: null,
   },
 ]);
+
+useEffect(() => {
+  asyncFetch(`${REPL_RPC_URL}`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "dontcare",
+      method: "query",
+      params: {
+        request_type: "view_state",
+        finality: "final",
+        account_id: lockupContract,
+        prefix_base64: "",
+      },
+    }),
+  }).then((res) => {
+    const lockupState = atob(res.body?.result?.values?.[0].value);
+    const deserialized = deserializeLockupContract(
+      new Uint8Array([...lockupState].map((c) => c.charCodeAt(0)))
+    );
+    const stakingPoolId = deserialized.staking_pool_whitelist_account_id
+      ? deserialized.staking_pool_whitelist_account_id.toString()
+      : null;
+    const isStakingAllowed = stakingPoolId === "lockup-no-whitelist.near";
+    setLockupStakingAllowed(!isStakingAllowed);
+  });
+}, [lockupContract]);
 
 useEffect(() => {
   if (
@@ -77,51 +113,58 @@ const Container = styled.div`
   }
 `;
 
+if (!isLockupStakingAllowed) return <></>;
+
 return (
   <Container>
-    <Widget
-      src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.DropDown`}
-      props={{
-        options: walletOptions,
-        selectedValue,
-        SelectedValueRender: () => {
-          return (
-            <div className="d-flex gap-2 align-items-center">
-              <div className="custom-tag rounded-3 text-sm text-center">
-                {selectedValue?.value === treasuryDaoID
-                  ? "SputnikDAO"
-                  : "Lockup"}
+    <div className="d-flex flex-column gap-1">
+      <label>Treasury Wallet</label>
+      <Widget
+        src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.DropDown`}
+        props={{
+          options: walletOptions,
+          selectedValue,
+          SelectedValueRender: () => {
+            return (
+              <div className="d-flex gap-2 align-items-center">
+                <div className="custom-tag rounded-3 text-sm text-center">
+                  {selectedValue?.value === treasuryDaoID
+                    ? "SputnikDAO"
+                    : "Lockup"}
+                </div>
+                <div className="text-truncate flex-1">
+                  {selectedValue?.value}
+                </div>
               </div>
-              <div className="text-truncate flex-1">{selectedValue?.value}</div>
-            </div>
-          );
-        },
-        onUpdate,
-        DropdownItemRender: ({ item, setSelected, selected }) => {
-          return (
-            <li
-              key={item.value}
-              className="dropdown-item cursor-pointer link-underline link-underline-opacity-0 d-flex gap-2 text-sm justify-content-between align-items-center"
-              onClick={() => {
-                if (selected.label !== item.label) {
-                  setSelected(item);
-                }
-              }}
-            >
-              <div className="custom-tag rounded-3 text-sm text-center">
-                {item.label === treasuryDaoID ? "SputnikDAO" : "Lockup"}
-              </div>
-              <div className="fw-bold work-break text-left flex-1">
-                {" "}
-                {item.label}
-              </div>
-              {item.balance && (
-                <div className="text-secondary w-15"> ${item.balance}</div>
-              )}
-            </li>
-          );
-        },
-      }}
-    />
+            );
+          },
+          onUpdate,
+          DropdownItemRender: ({ item, setSelected, selected }) => {
+            return (
+              <li
+                key={item.value}
+                className="dropdown-item cursor-pointer link-underline link-underline-opacity-0 d-flex gap-2 text-sm justify-content-between align-items-center"
+                onClick={() => {
+                  if (selected.label !== item.label) {
+                    setSelected(item);
+                  }
+                }}
+              >
+                <div className="custom-tag rounded-3 text-sm text-center">
+                  {item.label === treasuryDaoID ? "SputnikDAO" : "Lockup"}
+                </div>
+                <div className="fw-bold work-break text-left flex-1">
+                  {" "}
+                  {item.label}
+                </div>
+                {item.balance && (
+                  <div className="text-secondary w-15"> ${item.balance}</div>
+                )}
+              </li>
+            );
+          },
+        }}
+      />
+    </div>
   </Container>
 );

--- a/instances/widgets.treasury-factory.near/widget/lib/common.jsx
+++ b/instances/widgets.treasury-factory.near/widget/lib/common.jsx
@@ -811,6 +811,151 @@ async function asyncAccountToLockup(accountId) {
   });
 }
 
+function deserializeLockupContract(byteArray) {
+  let offset = 0;
+
+  function readU8() {
+    return byteArray[offset++];
+  }
+
+  function readU32() {
+    const bytes = [
+      byteArray[offset++],
+      byteArray[offset++],
+      byteArray[offset++],
+      byteArray[offset++],
+    ];
+    let result = new BN(0);
+    for (let i = 0; i < 4; i++) {
+      result = result.add(new BN(bytes[i]).mul(new BN(256).pow(new BN(i))));
+    }
+    return result;
+  }
+
+  function readU64() {
+    const bytes = Array(8)
+      .fill(0)
+      .map(() => byteArray[offset++]);
+    let result = new BN(0);
+    for (let i = 0; i < 8; i++) {
+      result = result.add(new BN(bytes[i]).mul(new BN(256).pow(new BN(i))));
+    }
+    return result;
+  }
+
+  function readU128() {
+    const bytes = Array(16)
+      .fill(0)
+      .map(() => byteArray[offset++]);
+    let result = new BN(0);
+    for (let i = 0; i < 16; i++) {
+      result = result.add(new BN(bytes[i]).mul(new BN(256).pow(new BN(i))));
+    }
+    return result;
+  }
+
+  function readString() {
+    const length = readU32().toNumber();
+    const strBytes = byteArray.slice(offset, offset + length);
+    offset += length;
+    return String.fromCharCode(...strBytes);
+  }
+
+  function readOption(reader) {
+    const hasValue = readU8() === 1;
+    return hasValue ? reader() : null;
+  }
+
+  function readVecU8() {
+    const length = readU32();
+    const bytes = byteArray.slice(offset, offset + length);
+    offset += length;
+    return Array.from(bytes);
+  }
+
+  // Deserialize TransfersInformation enum
+  function readTransfersInformation() {
+    const variant = readU8();
+    if (variant === 0) {
+      return {
+        type: "TransfersEnabled",
+        transfers_timestamp: readU64(),
+      };
+    } else if (variant === 1) {
+      return {
+        type: "TransfersDisabled",
+        transfer_poll_account_id: readString(),
+      };
+    }
+    console.log("var", variant);
+    throw `Invalid TransfersInformation variant ${variant}`;
+  }
+
+  // Deserialize TransactionStatus enum
+  function readTransactionStatus() {
+    const variant = readU8();
+    return variant === 0 ? "Idle" : "Busy";
+  }
+
+  // Deserialize VestingSchedule
+  function readVestingSchedule() {
+    return {
+      start_timestamp: readU64(),
+      cliff_timestamp: readU64(),
+      end_timestamp: readU64(),
+    };
+  }
+
+  // Deserialize VestingInformation enum
+  function readVestingInformation() {
+    const variant = readU8();
+    switch (variant) {
+      case 0:
+        return { type: "None" };
+      case 1:
+        return {
+          type: "VestingHash",
+          hash: readVecU8(),
+        };
+      case 2:
+        return {
+          type: "VestingSchedule",
+          schedule: readVestingSchedule(),
+        };
+      case 3:
+        return {
+          type: "Terminating",
+          unvested_amount: readU128(),
+          status: readU8(), // TerminationStatus as simple u8 for now
+        };
+      default:
+        throw new Error("Invalid VestingInformation variant");
+    }
+  }
+
+  const result = {
+    owner_account_id: readString(),
+    lockup_information: {
+      lockup_amount: readU128(),
+      termination_withdrawn_tokens: readU128(),
+      lockup_duration: readU64(),
+      release_duration: readOption(readU64),
+      lockup_timestamp: readOption(readU64),
+      transfers_information: readTransfersInformation(),
+    },
+    vesting_information: readVestingInformation(),
+    staking_pool_whitelist_account_id: readString(),
+    staking_information: readOption(() => ({
+      staking_pool_account_id: readString(),
+      status: readTransactionStatus(),
+      deposit_amount: readU128(),
+    })),
+    foundation_account_id: readOption(readString),
+  };
+
+  return result;
+}
+
 return {
   getApproversAndThreshold,
   hasPermission,
@@ -834,4 +979,5 @@ return {
   decodeBase64,
   accountToLockup,
   asyncAccountToLockup,
+  deserializeLockupContract,
 };

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/CreatePaymentRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/CreatePaymentRequest.jsx
@@ -466,23 +466,20 @@ return (
 
     <div className="d-flex flex-column gap-3">
       {lockupContract && (
-        <div className="d-flex flex-column gap-1">
-          <label>Treasury Wallet</label>
-          <Widget
-            src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.WalletDropdown`}
-            props={{
-              lockupNearBalances,
-              instance,
-              selectedValue: selectedWallet,
-              onUpdate: (v) => {
-                if (v.value !== selectedWallet.value) {
-                  cleanInputs();
-                }
-                setSelectedWallet(v);
-              },
-            }}
-          />
-        </div>
+        <Widget
+          src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.WalletDropdown`}
+          props={{
+            lockupNearBalances,
+            instance,
+            selectedValue: selectedWallet,
+            onUpdate: (v) => {
+              if (v.value !== selectedWallet.value) {
+                cleanInputs();
+              }
+              setSelectedWallet(v);
+            },
+          }}
+        />
       )}
       {showProposalSelection && (
         <div className="d-flex flex-column gap-1">

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateStakeRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateStakeRequest.jsx
@@ -444,21 +444,18 @@ return (
     />
     <div className="d-flex flex-column gap-3">
       {lockupContract && (
-        <div className="d-flex flex-column gap-1">
-          <label>Treasury Wallet</label>
-          <Widget
-            src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.WalletDropdown`}
-            props={{
-              lockupNearBalances,
-              instance,
-              selectedValue: selectedWallet,
-              onUpdate: (v) => {
-                setValidatorAccount(null);
-                setSelectedWallet(v);
-              },
-            }}
-          />
-        </div>
+        <Widget
+          src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.WalletDropdown`}
+          props={{
+            lockupNearBalances,
+            instance,
+            selectedValue: selectedWallet,
+            onUpdate: (v) => {
+              setValidatorAccount(null);
+              setSelectedWallet(v);
+            },
+          }}
+        />
       )}
       <div className="d-flex flex-column gap-1 border border-1 rounded-3 py-2">
         <BalanceDisplay

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateUnstakeRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateUnstakeRequest.jsx
@@ -429,21 +429,18 @@ return (
     />
     <div className="d-flex flex-column gap-3">
       {lockupContract && (
-        <div className="d-flex flex-column gap-1">
-          <label>Treasury Wallet</label>
-          <Widget
-            src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.WalletDropdown`}
-            props={{
-              lockupNearBalances,
-              instance,
-              selectedValue: selectedWallet,
-              onUpdate: (v) => {
-                setValidatorAccount(null);
-                setSelectedWallet(v);
-              },
-            }}
-          />
-        </div>
+        <Widget
+          src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.WalletDropdown`}
+          props={{
+            lockupNearBalances,
+            instance,
+            selectedValue: selectedWallet,
+            onUpdate: (v) => {
+              setValidatorAccount(null);
+              setSelectedWallet(v);
+            },
+          }}
+        />
       )}
       <div className="d-flex flex-column gap-1 border border-1 rounded-3 py-2">
         <BalanceDisplay

--- a/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateWithdrawRequest.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/stake-delegation/CreateWithdrawRequest.jsx
@@ -420,21 +420,18 @@ return (
     )}
     <div className="d-flex flex-column gap-3">
       {lockupContract && (
-        <div className="d-flex flex-column gap-1">
-          <label>Treasury Wallet</label>
-          <Widget
-            src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.WalletDropdown`}
-            props={{
-              lockupNearBalances,
-              instance,
-              selectedValue: selectedWallet,
-              onUpdate: (v) => {
-                setShowLoader(true);
-                setSelectedWallet(v);
-              },
-            }}
-          />
-        </div>
+        <Widget
+          src={`${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.WalletDropdown`}
+          props={{
+            lockupNearBalances,
+            instance,
+            selectedValue: selectedWallet,
+            onUpdate: (v) => {
+              setShowLoader(true);
+              setSelectedWallet(v);
+            },
+          }}
+        />
       )}
       <div className="d-flex flex-column gap-1 border border-1 rounded-3 py-2">
         <BalanceDisplay

--- a/playwright-tests/tests/stake-delegation/stake-delegation.spec.js
+++ b/playwright-tests/tests/stake-delegation/stake-delegation.spec.js
@@ -238,6 +238,7 @@ export async function mockLockupNearBalances({ page, balance }) {
 }
 
 async function selectLockupAccount({ page, daoAccount, lockupContract }) {
+  await page.waitForTimeout(5_000);
   await page.getByRole("button", { name: daoAccount }).click();
   await page.getByText(lockupContract).click();
 }
@@ -337,6 +338,37 @@ async function checkForStakeAmount({ page, errorText, availableBalance }) {
   await expect(amountErrorText).toBeHidden();
 }
 
+async function mockLockupState({ page, lockupContract }) {
+  await page.route(`https://rpc.mainnet.near.org`, async (route) => {
+    const request = await route.request();
+    const requestPostData = await request.postDataJSON();
+
+    if (
+      requestPostData.params &&
+      requestPostData.params.account_id === lockupContract &&
+      requestPostData.params.request_type === "view_state"
+    ) {
+      const json = {
+        jsonrpc: "2.0",
+        result: {
+          block_hash: "2Dc8Jh8mFU8bKe16hAVcZ3waQhhdfUXwvvnsDP9djN95",
+          block_height: 140432800,
+          values: [
+            {
+              key: "U1RBVEU=",
+              value:
+                "DAAAAG1lZ2hhMTkubmVhcgAAACWkAAqLyiIEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAABPkZROAAABAACi6omWKxgAfKTy6T+hPRYAGAAAAGxvY2t1cC1uby13aGl0ZWxpc3QubmVhcgAA",
+            },
+          ],
+        },
+        id: "dontcare",
+      };
+      await route.fulfill({ json });
+    } else {
+      await route.continue();
+    }
+  });
+}
 const NEAR_DIVISOR = 10n ** 24n;
 
 function formatNearAmount(amount) {
@@ -1425,6 +1457,37 @@ test.describe("Lockup staking", function () {
             },
           },
         },
+      });
+    });
+  });
+
+  test.describe("Wallet dropdown shouldn't be visible when staking is not allowed", () => {
+    const dropdownOptions = [
+      { name: "Stake", option: 1 },
+      { name: "Unstake", option: 2 },
+      { name: "Withdraw", option: 3 },
+    ];
+
+    dropdownOptions.forEach(({ name, option }) => {
+      test(`shouldn't display wallet dropdown selector when opening ${name} request`, async ({
+        page,
+        lockupContract,
+      }) => {
+        test.setTimeout(120_000);
+        await expect(
+          page.getByText("Create Request", { exact: true })
+        ).toBeVisible();
+        await mockLockupState({ page, lockupContract });
+        await page.locator(".custom-select > .dropdown").first().click();
+        await page.locator(`.dropdown-menu > div:nth-child(${option})`).click();
+        await expect(page.getByText("Ready to stake")).toBeVisible(10_000);
+        await expect(
+          page.getByRole("heading", { name: `Create ${name} Request` })
+        ).toBeVisible(10_000);
+        await page.waitForTimeout(5_000);
+        await expect(
+          page.locator(".offcanvas-body").getByText("Treasury Wallet")
+        ).toBeHidden();
       });
     });
   });


### PR DESCRIPTION
In lockup creation, staking is optional, allowing users to disable staking for the lockup contract. To support this in the UI, we hide the lockup option in the stake request when staking is not allowed, which we check using the contract state, where `staking_pool_whitelist_account_id = lockup-no-whitelist.near`.