### PR TITLE
Minor css change

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/components/Tabs.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/Tabs.jsx
@@ -63,6 +63,13 @@ useEffect(() => {
   }
 }, [props]);
 
+// needed to pass props to child related to current tab
+useEffect(() => {
+  if (typeof props.setCurrentTab === "function") {
+    props.setCurrentTab(currentTab);
+  }
+}, [currentTab]);
+
 return (
   <Container className="card py-3 d-flex flex-column">
     <div

--- a/instances/widgets.treasury-factory.near/widget/components/Votes.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/Votes.jsx
@@ -64,7 +64,7 @@ return (
       </div>
       {isProposalDetailsPage && (
         <div className="text-secondary text-xs">
-          Required votes: {requiredVotes}
+          Required Votes: {requiredVotes}
         </div>
       )}
       <div className="w-100 h-100 flex-item label red">

--- a/instances/widgets.treasury-factory.near/widget/pages/asset-exchange/ExchangeForm.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/asset-exchange/ExchangeForm.jsx
@@ -224,8 +224,15 @@ const code = `
             .custom-tooltip {
                 --bs-tooltip-bg:${colors["--bg-system-color"]}  !important;
                 --bs-tooltip-color:${colors["--text-color"]} !important;
-              }
+                width: 300px !important;
+                font-size: 13px;
+              }              
             
+              .tooltip-inner {
+                max-width: 300px !important;
+                width: 300px !important;
+                white-space: normal; /* allow text wrapping */
+              }
             </style>
         </head>
         <body data-bs-theme=${isDarkTheme ? "dark" : "light"}>
@@ -413,7 +420,7 @@ const code = `
                         data-bs-toggle="tooltip"
                         data-bs-custom-class="custom-tooltip"
                         data-bs-placement="top"
-                        title="This fee is collected by Ref Finance and shared with liquidity providers as a reward for providing liquidity to the pool"
+                        title="This fee is collected by Ref Finance and shared with liquidity providers as a reward for providing liquidity to the pool."
                     >
                     </i>
                     </div>
@@ -633,11 +640,18 @@ const code = `
                 const slippageError = document.getElementById("slippage-error");
 
                 var tooltipTriggerList = [].slice.call(
-                document.querySelectorAll('[data-bs-toggle="tooltip"]'),
-                );
-                tooltipTriggerList.map(function (tooltipTriggerEl) {
-                return new bootstrap.Tooltip(tooltipTriggerEl);
-                });
+                    document.querySelectorAll('[data-bs-toggle="tooltip"]')
+                  );
+                  
+                  tooltipTriggerList.map(function (tooltipTriggerEl) {
+                    return new bootstrap.Tooltip(tooltipTriggerEl, {
+                      html: true,
+                      delay: { show: 300, hide: 500 },
+                      customClass: 'custom-tooltip',
+                      trigger: 'hover focus'
+                    });  
+                });                  
+                  
 
                 // Select the exchange rate elements and the toggle button
                 const sendExchangeRate = document.getElementById("send-exchange-rate");

--- a/instances/widgets.treasury-factory.near/widget/pages/asset-exchange/ExchangeForm.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/asset-exchange/ExchangeForm.jsx
@@ -231,7 +231,7 @@ const code = `
               .tooltip-inner {
                 max-width: 300px !important;
                 width: 300px !important;
-                white-space: normal; /* allow text wrapping */
+                white-space: normal;
               }
             </style>
         </head>

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
@@ -429,7 +429,9 @@ const CopyComponent = () => {
 const Navbar = () => {
   return !isCompactVersion ? (
     <div className="d-flex justify-content-between gap-2 align-items-center">
-      <a href={`?page=payments`}>
+      <a
+        href={`?page=payments${props?.tab === "history" ? "&tab=history" : ""}`}
+      >
         <button className="btn btn-outline-secondary d-flex gap-1 align-items-center">
           <i class="bi bi-arrow-left"></i> Back
         </button>
@@ -560,7 +562,9 @@ return (
               <CopyComponent />
               <a
                 className="cursor-pointer"
-                href={`?page=payments&id=${proposalData.id}`}
+                href={`?page=payments${
+                  props?.currentTab?.title === "History" ? "&tab=history" : ""
+                }&id=${proposalData.id}`}
               >
                 <i class="bi bi-arrows-angle-expand h5 mb-0"></i>
               </a>

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/index.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/index.jsx
@@ -26,6 +26,7 @@ const hasCreatePermission = hasPermission(
   "transfer",
   "AddProposal"
 );
+const [currentTab, setCurrentTab] = useState(null);
 
 const proposalDetailsPageId =
   id || id === "0" || id === 0 ? parseInt(id) : null;
@@ -217,6 +218,7 @@ return (
               props={{
                 ...props,
                 selectedProposalDetailsId: showProposalDetailsId,
+                setCurrentTab,
                 highlightProposalId:
                   props.highlightProposalId || voteProposalId,
                 tabs: [
@@ -261,6 +263,7 @@ return (
                   onClose: () => setShowProposalId(null),
                   setToastStatus,
                   setVoteProposalId,
+                  currentTab,
                 }}
               />
             )}

--- a/playwright-tests/tests/payments/proposal-details.spec.js
+++ b/playwright-tests/tests/payments/proposal-details.spec.js
@@ -77,10 +77,21 @@ async function checkProposalDetailPage({
     );
     const heading = page.getByRole("heading", { name: "#0" });
     await expect(heading).toBeVisible();
-    const cancelBtn = await page.locator(".cursor-pointer > .bi").first();
-    await cancelBtn.click();
-    await expect(heading).toBeHidden();
-    await expect(highlightedProposalRow).not.toHaveClass("bg-highlight");
+    if (!notInProgress || status === "Approved") {
+      await page.getByRole("link", { name: "" }).click();
+      const backBtn = await page.getByRole("button", { name: " Back" });
+      await backBtn.click();
+      const newUrl = await page.url();
+      await expect(newUrl).toBe(
+        `http://localhost:8080/${instanceAccount}/widget/app?page=payments` +
+          (notInProgress ? "&tab=history" : "")
+      );
+    } else {
+      const cancelBtn = await page.locator(".cursor-pointer > .bi").first();
+      await cancelBtn.click();
+      await expect(heading).toBeHidden();
+      await expect(highlightedProposalRow).not.toHaveClass("bg-highlight");
+    }
   } else {
     const copyLink = await page.getByText("Copy link");
     await copyLink.click();


### PR DESCRIPTION
- increase width of tooltip for better readability
<img width="498" alt="image" src="https://github.com/user-attachments/assets/5d3354c8-8c99-4532-9ced-1bc722591a2c" />

- I go to Payments > history, click on a payment for detailed view. Click expand. Then I click back, and it now takes back to History instead of Pending Requests, updated tests.