### PR TITLE
System updates for specified instances and developer docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ test-results
 build
 .env
 devstoragestate.json
+file_list.txt
+*.mp4
+freeze_frames

--- a/README.md
+++ b/README.md
@@ -39,6 +39,33 @@ ffmpeg -i test-results/stake-delegation-stake-delegation-admin-connected-Should-
 
 The resulting mp4 file can be directly dragged into the Pull Request description.
 
+## Playwright Video Merger Script
+
+The `playwright-video-merger.sh` script is used to process and combine Playwright test videos into a single, presentation-ready video file. It is especially useful for creating demo or showcase videos from your automated test runs.
+
+### What the Script Does
+- **Finds all Playwright test videos** (`video.webm`) in the `test-results/` directory.
+- **Overlays the test title** (from `test-title.txt` if available, or the folder name as a fallback) as a subtitle at the bottom of each video.
+- **Converts each video to mp4** format for compatibility and better compression.
+- **Appends a 1-second freeze frame** (last frame of the test video) to the end of each video segment, making transitions clearer.
+- **Concatenates all processed videos** (with freeze frames) into a single output file: `final_output.mp4`.
+
+### How to Use
+1. **Run your Playwright tests** with video recording enabled. The test videos will be saved in the `test-results/` directory.
+2. **Ensure test titles are saved**: The test suite should write the test title to a `test-title.txt` file in each test's video folder (this is handled by the provided `afterEach` hook in your tests).
+3. **Run the script:**
+   ```bash
+   ./playwright-video-merger.sh
+   ```
+4. **Find your merged video:** The final output will be saved as `final_output.mp4` in the root of your workspace.
+
+### Notes
+- The script also creates intermediate processed videos in the `processed_videos/` directory and freeze frames in the `freeze_frames/` directory.
+- If `test-title.txt` is missing, the script will use the folder name as the overlay text.
+- You can adjust the text wrapping and overlay style by editing the script variables.
+
+This workflow is ideal for creating clear, annotated demo videos from your Playwright test runs, making it easy to share test results or showcase features.
+
 ## Running a Development Server using PlayWright hosted web4 gateway
 
 To start the development server, use the following command:

--- a/docs/developer/system-updates.md
+++ b/docs/developer/system-updates.md
@@ -119,7 +119,7 @@ The following update types are supported. Set the `type` field in your update ob
 ```
 
 **How to use these types:**
-When creating an update in the UpdateRegistry, set the `type` field to one of the above string values. The system will handle each type appropriately, showing the correct UI and triggering the right actions (such as contract upgrade, widget update, or policy proposal).
+When creating an update in the UpdateRegistry, set the `type` field to one of the supported string values listed above. If you need a different type, you'll have to add support for it first. The system will handle each type appropriately, showing the correct UI and triggering the right actions (such as contract upgrade, widget update, or policy proposal).
 
 For more details or to see usage in tests, check the Playwright test cases for system updates, which demonstrate publishing and applying each type.
 

--- a/docs/developer/system-updates.md
+++ b/docs/developer/system-updates.md
@@ -21,8 +21,7 @@ Updates are defined as JavaScript objects in the `UpdateRegistry` widget. Each u
 - `summary` (string): Short summary of the update.
 - `details` (string): Detailed description (optional).
 - `instances` (array of strings): (Optional) List of instance account IDs that should receive this update. If omitted, the update is shown to all instances.
-- `votingRequired` (boolean): Whether a vote is required for this update.
-
+- `votingRequired` (boolean): Whether a DAO vote by admin is required after the update request is created.
 ## Example: Publishing an Update for All Instances
 
 ```js

--- a/docs/developer/system-updates.md
+++ b/docs/developer/system-updates.md
@@ -14,7 +14,7 @@ The system update functionality allows developers to publish updates that has to
 
 Updates are defined as JavaScript objects in the `UpdateRegistry` widget. Each update record can include the following fields:
 
-- `id` (number): Unique identifier for the update.
+- `id` (number): Unique identifier for the update, in numerical order. For any new update you should use a new id, incremented with one from the previous.
 - `createdDate` (string): Date of the update in `YYYY-MM-DD` format.
 - `version` (string): Version or label for the update (optional).
 - `type` (string): Type/category of the update (e.g., "DAO contract").

--- a/docs/developer/system-updates.md
+++ b/docs/developer/system-updates.md
@@ -1,0 +1,176 @@
+# System Updates: Publishing and Targeting Updates
+
+## Where to Add Updates
+
+All system updates are defined in a single shared UpdateRegistry widget file. To publish or modify updates, edit the following file:
+
+[instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/UpdateRegistry.jsx](../../instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/UpdateRegistry.jsx)
+
+> **Note:** All instances share this UpdateRegistry file. Updates published here will be visible to all instances unless using the `instances` property for targeting specific instances as described below.
+
+The system update functionality allows developers to publish updates that has to be applied and approved manually by treasury administrators (such as contract upgrades, policy changes, or instance app widget changes) to specific treasury instances or to all. This is managed through the `UpdateRegistry` widget and can be tested or previewed using the Playwright test suite.
+
+## How Updates Are Defined
+
+Updates are defined as JavaScript objects in the `UpdateRegistry` widget. Each update record can include the following fields:
+
+- `id` (number): Unique identifier for the update.
+- `createdDate` (string): Date of the update in `YYYY-MM-DD` format.
+- `version` (string): Version or label for the update (optional).
+- `type` (string): Type/category of the update (e.g., "DAO contract").
+- `summary` (string): Short summary of the update.
+- `details` (string): Detailed description (optional).
+- `instances` (array of strings): (Optional) List of instance account IDs that should receive this update. If omitted, the update is shown to all instances.
+- `votingRequired` (boolean): Whether a vote is required for this update.
+
+## Example: Publishing an Update for All Instances
+
+```js
+return [
+  {
+    id: 1,
+    createdDate: "2025-03-25",
+    version: "n/a",
+    type: "DAO contract",
+    summary: "Update to latest sputnik-dao contract",
+    details: "",
+    votingRequired: true,
+  }
+];
+```
+
+## Example: Publishing an Update for Specific Instances
+
+```js
+return [
+  {
+    id: 1,
+    createdDate: "2025-03-25",
+    version: "n/a",
+    type: "DAO contract",
+    summary: "Update to latest sputnik-dao contract",
+    details: "",
+    instances: ["infinex.near", "treasury-testing.near"],
+    votingRequired: true,
+  }
+];
+```
+
+In this example, only the specified instances will see the update notification.
+
+## Update Types
+
+The following update types are supported. Set the `type` field in your update object to one of these string values:
+
+### 1. Web4 Contract (`"Web4 Contract"`)
+**Description:** Used to upgrade the underlying Web4 smart contract for the treasury instance to the latest version. Applying this update triggers a self-upgrade of the contract.
+**Example:**
+```js
+{
+  id: 1,
+  createdDate: "2025-05-02",
+  type: "Web4 Contract",
+  summary: "Upgrade Web4 contract to the latest version",
+  details: "This update will upgrade your Web4 contract to the latest release from the factory.",
+  votingRequired: false
+}
+```
+
+### 2. Widgets (`"Widgets"`)
+**Description:** Updates the main application widget (typically `app.jsx`) to the latest version from the reference account. Ensures the UI and logic are up-to-date with the latest features and bug fixes.
+**Example:**
+```js
+{
+  id: 2,
+  createdDate: "2025-05-02",
+  type: "Widgets",
+  summary: "Update app.jsx widget",
+  details: "This update will synchronize your app widget with the latest version from the reference implementation.",
+  votingRequired: false
+}
+```
+
+### 3. Policy (`"Policy"`)
+**Description:** Updates that change the DAO policy, such as voting rules, roles, or permissions. Applying this update creates a proposal to change the policy on the DAO contract.
+**Example:**
+```js
+{
+  id: 3,
+  createdDate: "2025-05-02",
+  type: "Policy",
+  summary: "Update DAO policy",
+  details: "This update proposes changes to the DAO policy, such as new voting thresholds or role assignments.",
+  votingRequired: true
+}
+```
+
+### 4. DAO contract (`"DAO contract"`)
+**Description:** Upgrades the DAO contract itself (e.g., to a new version of Sputnik DAO). May involve deploying new contract code or migrating state.
+**Example:**
+```js
+{
+  id: 4,
+  createdDate: "2025-05-02",
+  type: "DAO contract",
+  summary: "Upgrade DAO contract to latest Sputnik version",
+  details: "This update will upgrade your DAO contract to the latest supported version.",
+  votingRequired: true
+}
+```
+
+**How to use these types:**
+When creating an update in the UpdateRegistry, set the `type` field to one of the above string values. The system will handle each type appropriately, showing the correct UI and triggering the right actions (such as contract upgrade, widget update, or policy proposal).
+
+For more details or to see usage in tests, check the Playwright test cases for system updates, which demonstrate publishing and applying each type.
+
+## How System Updates Work for Users
+
+When a system update is published, users may see a notification banner or badge indicating that a new update is available for their treasury instance. This is designed to help administrators and users stay informed about important changes, such as contract upgrades or policy updates.
+
+### How Update Status is Tracked
+- **Local Storage:**
+  - The status of which updates have been applied or acknowledged is tracked in your browser's local storage. This means the update banner or notification is specific to your browser and device.
+  - If you clear your browser storage or use a different browser/device, you may see update notifications again, even if you have already applied or dismissed them elsewhere.
+
+- **No Central Database:**
+  - There is no central server or database that tracks which updates have been applied for each instance or user. The system relies on local checks and the current state of your instance (e.g., contract version, widget version, policy) to determine if an update is still relevant.
+
+### What Users See
+- **Update Banner:**
+  - When an update is available and has not been marked as finished in your browser, a banner or notification will appear.
+  - If you visit the updates page and the system detects that your instance is already up to date (for example, the contract or widget has already been upgraded), the update will disappear from the list and the banner will be removed.
+
+- **Why Updates May Disappear:**
+  - If you see an update notification but then visit the updates page and the update disappears, this means the system has checked your instance and determined that the update is no longer needed (e.g., the upgrade was already applied, possibly by another admin or in another browser).
+  - This can be confusing, but it is expected behavior due to the decentralized and stateless nature of the update tracking system.
+
+### Tips for Users
+- If you want to keep a record of which updates have been applied, consider keeping your browser storage intact or using the same device for administrative actions.
+- If you are collaborating with other admins, be aware that update status is not synchronized between users—each admin's browser tracks updates independently, but the system will always check the actual state of the instance before showing or hiding updates.
+
+---
+
+## How to Publish an Update
+
+1. **Edit the Shared UpdateRegistry Widget:**
+   - All system updates are defined in a single shared file for all instances:  
+     [`instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/UpdateRegistry.jsx`](../../instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/UpdateRegistry.jsx)
+   - Open this file and return an array of update objects as shown in the examples above.
+
+2. **Targeting Instances:**
+   - To target specific treasury instances, add the `instances` field with an array of account IDs.
+   - If you omit the `instances` field, the update will be visible to all instances.
+
+3. **Testing Your Update:**
+   - You can use Playwright tests (see `playwright-tests/tests/system-updates/update-specfied-instances.spec.js`) to verify how updates appear for different instances and users.
+
+> **Note:** Only the `app.jsx` widget is separate per instance. All system updates are managed centrally in the shared UpdateRegistry file.
+
+## Notes
+- The update system supports both global and targeted updates.
+- Users will see notifications for new updates and can review details as defined in the update object.
+- Use unique `id` values for each update to avoid conflicts.
+
+---
+
+For more advanced usage or automation, refer to the Playwright test cases for system updates, which demonstrate how to programmatically inject and verify updates in different scenarios.

--- a/docs/developer/system-updates.md
+++ b/docs/developer/system-updates.md
@@ -141,7 +141,7 @@ When a system update is published, users may see a notification banner or badge 
   - If you visit the updates page and the system detects that your instance is already up to date (for example, the contract or widget has already been upgraded), the update will disappear from the list and the banner will be removed.
 
 - **Why Updates May Disappear:**
-  - If you see an update notification but then visit the updates page and the update disappears, this means the system has checked your instance and determined that the update is no longer needed (e.g., the upgrade was already applied, possibly by another admin or in another browser).
+  - If you see an update notification but then visit the updates page and the update disappears, this means the system has checked your instance and determined that the update is no longer needed (e.g.,  the upgrade may have already been applied—possibly by another admin or from a different browser—or the update request might have already been created and is still pending a vote).
   - This can be confusing, but it is expected behavior due to the decentralized and stateless nature of the update tracking system.
 
 ### Tips for Users

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/AvailableUpdates.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/AvailableUpdates.jsx
@@ -7,7 +7,7 @@ const { Modal, ModalContent, ModalHeader, ModalFooter } = VM.require(
   "${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/lib.modal"
 );
 const {
-  updatesNotApplied,
+  updatesNotAppliedForInstance,
   finishedUpdates,
   setFinishedUpdates,
   UPDATE_TYPE_WEB4_CONTRACT,
@@ -16,7 +16,9 @@ const {
   UPDATE_TYPE_DAO_CONTRACT,
 } = VM.require(
   "${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/pages.settings.system-updates.UpdateNotificationTracker"
-) ?? { updatesNotApplied: [], setFinishedUpdates: () => {} };
+) ?? { updatesNotAppliedForInstance: () => [], setFinishedUpdates: () => {} };
+
+const updatesNotApplied = updatesNotAppliedForInstance(instance);
 
 const { checkIfPolicyIsUpToDate, applyPolicyUpdate } = VM.require(
   "${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/pages.settings.system-updates.PolicyUpdate"

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/DAOContractUpdate.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/DAOContractUpdate.jsx
@@ -76,7 +76,7 @@ function getDefaultCodeHash() {
 
 function checkIfDAOContractIsUpToDate(instance) {
   const {
-    updatesNotApplied,
+    updatesNotAppliedForInstance,
     finishedUpdates,
     proposedUpdates,
     setFinishedUpdates,
@@ -84,8 +84,9 @@ function checkIfDAOContractIsUpToDate(instance) {
     UPDATE_TYPE_DAO_CONTRACT,
   } = VM.require(
     "${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/pages.settings.system-updates.UpdateNotificationTracker"
-  ) ?? { updatesNotApplied: [], setFinishedUpdates: () => {} };
+  ) ?? { updatesNotAppliedForInstance: () => [], setFinishedUpdates: () => {} };
 
+  const updatesNotApplied = updatesNotAppliedForInstance(instance);
   const daoContractUpdatesNotApplied = updatesNotApplied.filter(
     (update) => update.type === UPDATE_TYPE_DAO_CONTRACT
   );

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/PolicyUpdate.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/PolicyUpdate.jsx
@@ -10,14 +10,15 @@ function getPolicy(instance) {
 
 function checkIfPolicyIsUpToDate(instance) {
   const {
-    updatesNotApplied,
+    updatesNotAppliedForInstance,
     finishedUpdates,
     setFinishedUpdates,
     UPDATE_TYPE_POLICY,
   } = VM.require(
     "${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/pages.settings.system-updates.UpdateNotificationTracker"
-  ) ?? { updatesNotApplied: [], setFinishedUpdates: () => {} };
+  ) ?? { updatesNotAppliedForInstance: () => [], setFinishedUpdates: () => {} };
 
+  const updatesNotApplied = updatesNotAppliedForInstance(instance);
   const { daoPolicy } = getPolicy(instance);
   updatesNotApplied
     .filter((update) => update.type === UPDATE_TYPE_POLICY)

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/UpdateNotificationBanner.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/UpdateNotificationBanner.jsx
@@ -1,17 +1,17 @@
-const { hasUpdates } = VM.require(
+const instance = props.instance;
+if (!instance) {
+  return <></>;
+}
+
+const { instanceHasUpdates } = VM.require(
   "${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/pages.settings.system-updates.UpdateNotificationTracker"
-) ?? { hasUpdates: false };
+) ?? { instanceHasUpdates: () => false };
 
 const { hasPermission } = VM.require(
   "${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/lib.common"
 ) || {
   hasPermission: () => false,
 };
-
-const instance = props.instance;
-if (!instance) {
-  return <></>;
-}
 
 const { treasuryDaoID } = VM.require(`${instance}/widget/config.data`);
 const hasEditPermission = hasPermission(
@@ -20,6 +20,8 @@ const hasEditPermission = hasPermission(
   "policy",
   "AddProposal"
 );
+
+const hasUpdates = instanceHasUpdates(instance);
 
 return hasEditPermission && hasUpdates ? (
   <div className="system-update-banner">

--- a/instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/UpdateNotificationTracker.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/settings/system-updates/UpdateNotificationTracker.jsx
@@ -18,12 +18,17 @@ const proposedUpdates = JSON.parse(
   Storage.get(STORAGE_KEY_PROPOSED_UPDATES) ?? "{}"
 );
 
-const updatesNotApplied = updateRegistry
-  .filter((update) => finishedUpdates[update.id] === undefined)
-  .map((update) => ({
-    ...update,
-    hasActiveProposal: proposedUpdates[update.id] !== undefined,
-  }));
+const updatesNotAppliedForInstance = (instance) =>
+  updateRegistry
+    .filter((update) => finishedUpdates[update.id] === undefined)
+    .filter(
+      (update) =>
+        update.instances === undefined || update.instances.includes(instance)
+    )
+    .map((update) => ({
+      ...update,
+      hasActiveProposal: proposedUpdates[update.id] !== undefined,
+    }));
 
 const appliedUpdates = updateRegistry.filter(
   (update) => finishedUpdates[update.id] !== undefined
@@ -31,12 +36,16 @@ const appliedUpdates = updateRegistry.filter(
 
 return {
   appliedUpdates,
-  updatesNotApplied,
+  updatesNotAppliedForInstance,
   proposedUpdates,
-  hasUpdates:
-    updatesNotApplied.length > 0 &&
-    updatesNotApplied.filter((update) => update.hasActiveProposal).length !==
-      updatesNotApplied.length,
+  instanceHasUpdates: (instance) => {
+    const updatesNotApplied = updatesNotAppliedForInstance(instance);
+    return (
+      updatesNotApplied.length > 0 &&
+      updatesNotApplied.filter((update) => update.hasActiveProposal).length !==
+        updatesNotApplied.length
+    );
+  },
   UPDATE_TYPE_WEB4_CONTRACT,
   UPDATE_TYPE_WIDGET,
   UPDATE_TYPE_POLICY,

--- a/playwright-tests/tests/system-updates/system-updates-feature-flag.spec.js
+++ b/playwright-tests/tests/system-updates/system-updates-feature-flag.spec.js
@@ -1,0 +1,116 @@
+import { expect } from "@playwright/test";
+import { test } from "../../util/test.js";
+import {
+  compareInstanceWeb4WithTreasuryFactory,
+  redirectWeb4,
+} from "../../util/web4.js";
+import { setPageAuthSettings } from "../../util/sandboxrpc.js";
+import { KeyPairEd25519 } from "near-workspaces";
+
+test.afterEach(async ({ page }) => {
+  await page.unrouteAll({ behavior: "ignoreErrors" });
+});
+
+test("should show system-update for targeted instance", async ({ page }) => {
+  const contractId = "treasury-testing.near";
+  await redirectWeb4({
+    contractId,
+    page,
+    modifiedWidgets: {
+      "widgets.treasury-factory.near/widget/pages.settings.system-updates.UpdateRegistry": `
+    return [
+      {
+        id: 1,
+        createdDate: "2025-03-25",
+        version: "n/a",
+        type: "DAO contract",
+        summary: "Update to latest sputnik-dao contract",
+        details: "",
+        instances: ["infinex.near", "treasury-testing.near"],
+        votingRequired: true,
+      }
+  ];
+  `,
+    },
+  });
+  await page.goto(`https://${contractId}.page/?page=settings`);
+  await setPageAuthSettings(page, "theori.near", KeyPairEd25519.fromRandom());
+
+  await expect(page.getByText("New system updates published")).toBeVisible();
+
+  await page.getByRole("link", { name: "Review" }).click();
+  await expect(
+    page.getByText("Update to latest sputnik-dao contract")
+  ).toBeVisible();
+});
+
+test("should not show system-update for others than targeted instances", async ({
+  page,
+}) => {
+  const contractId = "treasury-testing.near";
+  await redirectWeb4({
+    contractId,
+    page,
+    modifiedWidgets: {
+      "widgets.treasury-factory.near/widget/pages.settings.system-updates.UpdateRegistry": `
+      return [
+        {
+          id: 1,
+          createdDate: "2025-03-25",
+          version: "n/a",
+          type: "DAO contract",
+          summary: "Update to latest sputnik-dao contract",
+          details: "",
+          instances: ["infinex.near", "treasury-devdao.near"],
+          votingRequired: true,
+        }
+    ];
+    `,
+    },
+  });
+  await page.goto(`https://${contractId}.page/?page=settings`);
+  await setPageAuthSettings(page, "theori.near", KeyPairEd25519.fromRandom());
+
+  await expect(
+    page.getByText("New system updates published")
+  ).not.toBeVisible();
+
+  await page.getByRole("link", { name: "System updates" }).click();
+  await expect(
+    page.getByText("Update to latest sputnik-dao contract")
+  ).not.toBeVisible();
+});
+
+test("should show system-update if no target instances specified", async ({
+  page,
+}) => {
+  const contractId = "treasury-testing.near";
+  await redirectWeb4({
+    contractId,
+    page,
+    modifiedWidgets: {
+      "widgets.treasury-factory.near/widget/pages.settings.system-updates.UpdateRegistry": `
+      return [
+        {
+          id: 1,
+          createdDate: "2025-03-25",
+          version: "n/a",
+          type: "DAO contract",
+          summary: "Update to latest sputnik-dao contract",
+          details: "",
+          votingRequired: true,
+        }
+    ];
+    `,
+    },
+  });
+  await page.goto(`https://${contractId}.page/?page=settings`);
+  await setPageAuthSettings(page, "theori.near", KeyPairEd25519.fromRandom());
+
+  await expect(page.getByText("New system updates published")).toBeVisible();
+
+  await page.getByRole("link", { name: "Review" }).click();
+  await expect(
+    page.getByText("Update to latest sputnik-dao contract")
+  ).toBeVisible();
+});

--- a/playwright-tests/tests/system-updates/update-history.spec.js
+++ b/playwright-tests/tests/system-updates/update-history.spec.js
@@ -5,10 +5,6 @@ import {
   redirectWeb4,
 } from "../../util/web4.js";
 
-test.afterEach(async ({ page }) => {
-  await page.unrouteAll({ behavior: "ignoreErrors" });
-});
-
 test("should show update history", async ({ page, instanceAccount }) => {
   const contractId = instanceAccount;
   const isUpToDate = await compareInstanceWeb4WithTreasuryFactory(

--- a/playwright-tests/tests/system-updates/update-infinex-sputnikdao.spec.js
+++ b/playwright-tests/tests/system-updates/update-infinex-sputnikdao.spec.js
@@ -7,7 +7,6 @@ import {
   SPUTNIK_DAO_FACTORY_ID,
 } from "../../util/sandboxrpc";
 import crypto from "crypto";
-import { cacheCDN } from "../../util/test";
 
 test("update infinex.sputnik-dao.near", async ({ page }) => {
   test.setTimeout(120_000);
@@ -15,8 +14,6 @@ test("update infinex.sputnik-dao.near", async ({ page }) => {
   const daoContractId = `${daoName}.${SPUTNIK_DAO_FACTORY_ID}`;
   const web4ContractId = "treasury-infinex.near";
   const socialNearContractId = "social.near";
-
-  await cacheCDN(page);
 
   const worker = await Worker.init();
 

--- a/playwright-tests/tests/system-updates/update-infinex-sputnikdao.spec.js
+++ b/playwright-tests/tests/system-updates/update-infinex-sputnikdao.spec.js
@@ -1,4 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "../../util/test.js";
 import { Worker } from "near-workspaces";
 import nearApi from "near-api-js";
 import { redirectWeb4 } from "../../util/web4";

--- a/playwright-tests/tests/system-updates/update-policy.spec.js
+++ b/playwright-tests/tests/system-updates/update-policy.spec.js
@@ -1,5 +1,5 @@
 import { expect } from "@playwright/test";
-import { cacheCDN, test } from "../../util/test.js";
+import { test } from "../../util/test.js";
 import {
   DEFAULT_WIDGET_REFERENCE_ACCOUNT_ID,
   SandboxRPC,
@@ -12,8 +12,6 @@ test("should update sputnik-dao policy and upgrade instance with it", async ({
   page,
 }) => {
   test.setTimeout(120_000);
-
-  await cacheCDN(page);
 
   const sandbox = new SandboxRPC();
   await sandbox.init();

--- a/playwright-tests/tests/system-updates/update-specfied-instances.spec.js
+++ b/playwright-tests/tests/system-updates/update-specfied-instances.spec.js
@@ -3,9 +3,18 @@ import { test } from "../../util/test.js";
 import { redirectWeb4 } from "../../util/web4.js";
 import { setPageAuthSettings } from "../../util/sandboxrpc.js";
 import { KeyPairEd25519 } from "near-workspaces";
+import fs from "fs";
+import path from "path";
 
-test.afterEach(async ({ page }) => {
+test.afterEach(async ({ page }, testInfo) => {
   await page.unrouteAll({ behavior: "ignoreErrors" });
+  const video = await page.video();
+  if (video) {
+    const titleFile = testInfo.outputPath("test-title.txt");
+    
+    await fs.promises.writeFile(titleFile, testInfo.title);
+    console.log(`Written video title file ${titleFile}`);
+  }
 });
 
 test("should show system-update for targeted instance", async ({ page }) => {

--- a/playwright-tests/tests/system-updates/update-specfied-instances.spec.js
+++ b/playwright-tests/tests/system-updates/update-specfied-instances.spec.js
@@ -3,19 +3,6 @@ import { test } from "../../util/test.js";
 import { redirectWeb4 } from "../../util/web4.js";
 import { setPageAuthSettings } from "../../util/sandboxrpc.js";
 import { KeyPairEd25519 } from "near-workspaces";
-import fs from "fs";
-import path from "path";
-
-test.afterEach(async ({ page }, testInfo) => {
-  await page.unrouteAll({ behavior: "ignoreErrors" });
-  const video = await page.video();
-  if (video) {
-    const titleFile = testInfo.outputPath("test-title.txt");
-    
-    await fs.promises.writeFile(titleFile, testInfo.title);
-    console.log(`Written video title file ${titleFile}`);
-  }
-});
 
 test("should show system-update for targeted instance", async ({ page }) => {
   const contractId = "treasury-testing.near";
@@ -118,5 +105,5 @@ test("should show system-update if no target instances specified", async ({
   await page.getByRole("link", { name: "Review" }).click();
   await expect(
     page.getByText("Update to latest sputnik-dao contract")
-  ).toBeVisible();
+  ).toBeVisible({ timeout: 15_000 });
 });

--- a/playwright-tests/tests/system-updates/update-specfied-instances.spec.js
+++ b/playwright-tests/tests/system-updates/update-specfied-instances.spec.js
@@ -1,9 +1,6 @@
 import { expect } from "@playwright/test";
 import { test } from "../../util/test.js";
-import {
-  compareInstanceWeb4WithTreasuryFactory,
-  redirectWeb4,
-} from "../../util/web4.js";
+import { redirectWeb4 } from "../../util/web4.js";
 import { setPageAuthSettings } from "../../util/sandboxrpc.js";
 import { KeyPairEd25519 } from "near-workspaces";
 

--- a/playwright-tests/tests/system-updates/update-sputnikdao-contract.spec.js
+++ b/playwright-tests/tests/system-updates/update-sputnikdao-contract.spec.js
@@ -1,10 +1,5 @@
 import { expect } from "@playwright/test";
-import {
-  cacheCDN,
-  overlayMessage,
-  removeOverlayMessage,
-  test,
-} from "../../util/test.js";
+import { overlayMessage, removeOverlayMessage, test } from "../../util/test.js";
 import {
   DEFAULT_WIDGET_REFERENCE_ACCOUNT_ID,
   SandboxRPC,
@@ -16,8 +11,6 @@ import crypto from "crypto";
 
 test("should update sputnik-dao contract", async ({ page }) => {
   test.setTimeout(180_000);
-
-  await cacheCDN(page);
 
   const sandbox = new SandboxRPC();
   await sandbox.init();

--- a/playwright-tests/tests/system-updates/update-widgets.spec.js
+++ b/playwright-tests/tests/system-updates/update-widgets.spec.js
@@ -1,5 +1,5 @@
 import { expect } from "@playwright/test";
-import { cacheCDN, test } from "../../util/test.js";
+import { test } from "../../util/test.js";
 import {
   DEFAULT_WIDGET_REFERENCE_ACCOUNT_ID,
   SandboxRPC,
@@ -7,14 +7,11 @@ import {
 } from "../../util/sandboxrpc.js";
 import { createDAOargs } from "../../util/sputnikdao.js";
 import nearApi from "near-api-js";
-import { readFile } from "fs/promises";
 
 test("should update bootstrap widget and upgrade instance with it", async ({
   page,
 }) => {
   test.setTimeout(120_000);
-
-  await cacheCDN(page);
 
   const sandbox = new SandboxRPC();
   await sandbox.init();

--- a/playwright-tests/tests/system-updates/upgrade-instance.spec.js
+++ b/playwright-tests/tests/system-updates/upgrade-instance.spec.js
@@ -1,5 +1,5 @@
 import { expect } from "@playwright/test";
-import { cacheCDN, test } from "../../util/test.js";
+import { test } from "../../util/test.js";
 import {
   DEFAULT_WIDGET_REFERENCE_ACCOUNT_ID,
   SandboxRPC,
@@ -12,8 +12,6 @@ test("should update treasury factory with new web4 contract and self upgrade ins
   page,
 }) => {
   test.setTimeout(150_000);
-
-  await cacheCDN(page);
 
   const sandbox = new SandboxRPC();
   await sandbox.init();

--- a/playwright-tests/util/sandboxrpc.js
+++ b/playwright-tests/util/sandboxrpc.js
@@ -7,9 +7,6 @@ import { getLocalWidgetSource } from "./bos-workspace.js";
 import { expect } from "@playwright/test";
 import { overlayMessage, removeOverlayMessage } from "./test.js";
 import { getLocalWidgetContent, redirectWeb4 } from "./web4.js";
-import { readFile, writeFile, mkdir } from "fs/promises";
-import { tmpdir } from "os";
-import path from "path";
 
 export const SPUTNIK_DAO_CONTRACT_ID = "sputnik-dao.near";
 // we don't have proposal bond for any instance (in this repo)
@@ -627,6 +624,7 @@ export class SandboxRPC {
       page,
       treasury,
       networkId: "sandbox",
+      widgetNodeUrl: this.rpc_url,
       sandboxNodeUrl: this.rpc_url,
       modifiedWidgets: this.modifiedWidgets,
     });

--- a/playwright-tests/util/web4.js
+++ b/playwright-tests/util/web4.js
@@ -50,6 +50,7 @@ export function getLocalWidgetContent(key, context = {}) {
  * @param {string} [options.treasury] - The treasury account ID. If not provided, it will be derived from the contract ID.
  * @param {string} [options.networkId="mainnet"] - The NEAR network ID (default is "mainnet").
  * @param {string} [options.nodeUrl="https://rpc.mainnet.near.org"] - The NEAR RPC node URL (default is the mainnet RPC URL).
+ * @param {string} [options.widgetNodeUrl="https://rpc.mainnet.fastnear.com"] - NEAR RPC node URL to get widget content from ( defaults to mainnet ). Specify sandbox URL if you want to fetch from sandbox.
  * @param {string} [options.sandboxNodeUrl] - Fallback RPC requests will be sent to the sandbox if specified, otherwise to nodeUrl
  * @param {Object} [options.modifiedWidgets={}] - An object containing modified widget content.
  *     The keys are widget keys (e.g., "account/section/contentKey"), and the values are the modified widget content as strings.
@@ -62,6 +63,7 @@ export async function redirectWeb4({
   treasury,
   networkId = "mainnet",
   nodeUrl = "https://rpc.mainnet.near.org",
+  widgetNodeUrl = "https://rpc.mainnet.fastnear.com",
   sandboxNodeUrl,
   modifiedWidgets = {},
 }) {
@@ -70,7 +72,7 @@ export async function redirectWeb4({
   if (!treasury) {
     treasury = contractId.split(".")[0] + ".sputnik-dao.near";
   }
-  const redirectNodeUrl = sandboxNodeUrl ?? nodeUrl;
+  const redirectNodeUrl = sandboxNodeUrl ?? "https://rpc.mainnet.fastnear.com";
 
   const near = await connect({
     networkId,
@@ -88,7 +90,7 @@ export async function redirectWeb4({
 
       if ((keys && keys[0].startsWith(contractId)) || keys === undefined) {
         const response = await route.fetch({
-          url: redirectNodeUrl,
+          url: widgetNodeUrl,
           json: postData,
         });
         await route.fulfill({ response });
@@ -110,7 +112,7 @@ export async function redirectWeb4({
             const content = getLocalWidgetContent(key, {
               treasury,
               account,
-              nodeUrl: redirectNodeUrl,
+              nodeUrl,
             });
 
             if (content) {

--- a/playwright-video-merger.sh
+++ b/playwright-video-merger.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Define directories
+VIDEO_DIR="test-results"
+OUTPUT_DIR="processed_videos"
+FREEZE_FRAMES_DIR="freeze_frames"
+CONCAT_FILE="file_list.txt"
+FINAL_OUTPUT="final_output.mp4"
+TEXT_WRAP_LIMIT=40  # Adjust this limit based on your video width
+
+# Ensure output directories exist
+mkdir -p "$OUTPUT_DIR" "$FREEZE_FRAMES_DIR"
+
+# Clean up old files
+rm -f "$OUTPUT_DIR"/*.mp4 "$FREEZE_FRAMES_DIR"/*.mp4 "$CONCAT_FILE"
+
+echo "Processing Playwright test videos with a 1-second delay and wrapped subtitles..."
+
+# Find and process all video files
+find "$VIDEO_DIR" -type f -name "video.webm" | while read -r file; do
+    # Get the parent folder name as the test name
+    test_name=$(basename "$(dirname "$file")")
+
+    # Try to read the test title from test-title.txt if it exists
+    title_file="$(dirname "$file")/test-title.txt"
+    if [[ -f "$title_file" ]]; then
+        test_name_clean=$(cat "$title_file")
+    else
+        # Format name: Replace dashes with spaces
+        test_name_clean=$(echo "$test_name" | sed 's/-/ /g')
+    fi
+
+    # Wrap text if it's too long (insert a line break at the closest space)
+    if [[ ${#test_name_clean} -gt $TEXT_WRAP_LIMIT ]]; then
+        test_name_clean=$(echo "$test_name_clean" | sed -E "s/(.{1,$TEXT_WRAP_LIMIT}) /\1\n/")
+    fi
+
+    # Define output filenames
+    output_file="$OUTPUT_DIR/$test_name.mp4"
+    freeze_frame_file="$FREEZE_FRAMES_DIR/${test_name}_freeze.mp4"
+
+    echo "Processing: $file"
+    echo "Overlaying test name (wrapped): '$test_name_clean'"
+
+    # Convert webm to mp4 and overlay wrapped text at the bottom
+    ffmpeg -i "$file" -vf "drawtext=text='$test_name_clean':fontcolor=white:fontsize=24:x=(w-text_w)/2:y=h-text_h-30:box=1:boxcolor=black@0.5:boxborderw=5:line_spacing=10" -c:v libx264 -crf 23 -preset fast -c:a aac -b:a 128k "$output_file" -y
+
+    # Extract last frame and create a 1-second freeze frame
+    echo "Generating 1-second freeze frame..."
+    ffmpeg -sseof -0.1 -i "$output_file" -vframes 1 -q:v 2 "$FREEZE_FRAMES_DIR/${test_name}.jpg" -y
+    ffmpeg -loop 1 -t 1 -i "$FREEZE_FRAMES_DIR/${test_name}.jpg" -vf "scale=1280:-2" -c:v libx264 -crf 23 -preset fast -tune stillimage -pix_fmt yuv420p "$freeze_frame_file" -y
+
+    # Add both files to the concat list
+    echo "file '$output_file'" >> "$CONCAT_FILE"
+    echo "file '$freeze_frame_file'" >> "$CONCAT_FILE"
+done
+
+# Check if there are videos to concatenate
+if [[ -s "$CONCAT_FILE" ]]; then
+    echo "Concatenating all processed videos with delays..."
+
+    ffmpeg -f concat -safe 0 -i "$CONCAT_FILE" -c:v libx264 -crf 23 -preset fast -c:a aac -b:a 128k "$FINAL_OUTPUT" -y
+
+    echo "✅ Done! Final video saved as: $FINAL_OUTPUT"
+else
+    echo "❌ No valid videos found to concatenate!" >&2
+fi

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -34,7 +34,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     headless: true,
-    video: process.env.CI ? "off" : "retain-on-failure",
+    video: process.env.CI ? "off" : "on",
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -41,7 +41,7 @@ export default defineConfig({
     baseURL: "http://localhost:8080",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
+    trace: process.env.CI ? "on-first-retry" : "retain-on-failure",
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
Instead of a feature flag as described in #479, this PR adds the possibility of specifying which instances that will receive a system update. After some thought I believe this is more usable than introducing a feature flag that we later will remove. This approach also means that we can control which instances to upgrade centrally, rather than having to adjust the configuration of each instance. It might also be usable for future upgrades if we want to target specific instances first.

This PR also contains a documentation file, that describes how the system updates work and how to publish updates.

To publish an update to specified instances, you use the `instances` property of the update object. If the `instances` property is not specified, then all instances will be targeted.

Here's an example:

```javascript
 {
        id: 1,
        createdDate: "2025-03-25",
        version: "n/a",
        type: "DAO contract",
        summary: "Update to latest sputnik-dao contract",
        details: "",
        instances: ["infinex.near", "treasury-testing.near"],
        votingRequired: true,
      }
```

Here's how it appears from the different test cases:

https://github.com/user-attachments/assets/24f10614-6ea1-452b-8838-fe8535454429

The documentation here may also contain info that is relevant for users as requested in #477 

Done some refactorings to reduce the number of duplicate `beforeEach`, `afterEach` by having CDN caching and unrouting attached to the extended test function.

Refactored the `redirectWeb4` function to be common for sandbox and non-sandbox testing.

Finally there's also a script here for merging multiple playwright videos, and annotating with subtitles from the test title ( which was used to generate the test video here ).

resolves #479
resolves #397 