### PR TITLE
near workspaces setup for NEAR Intents payment requests

### DIFF
--- a/docs/developer/intents.md
+++ b/docs/developer/intents.md
@@ -59,7 +59,7 @@ This method allows for sending funds directly from the DAO (via `intents.near`) 
         *   `token`: The NEP-141 token ID of the asset to withdraw (e.g., `\"btc.omft.near\"`).
         *   `receiver_id`: This argument might specify the token contract ID (e.g., `btc.omft.near`) from which the withdrawal is being made or serve another internal purpose for `intents.near`. The actual recipient on the native chain is determined by the `memo`.
         *   `amount`: The quantity of the token to withdraw, as a string.
-        *   `memo`: This is critical. It must be formatted to specify the native chain and destination address. For example: `\"WITHDRAW_TO:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh\"`.
+        *   `memo`: This is critical. It must be formatted to specify the native chain and destination address. For example: `"WITHDRAW_TO:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh"`.
 
 2.  **Proposal Voting and Execution:**
     *   DAO members vote on the proposal.
@@ -83,3 +83,17 @@ This direct withdrawal mechanism via `ft_withdraw` offers significant advantages
 *   **Critical Memo Field:** The accuracy of the `memo` field, containing the native destination address and the correct `\"WITHDRAW_TO:\"` prefix, is essential for the successful execution of the withdrawal.
 
 This direct withdrawal capability allows DAOs on NEAR to fully manage payouts to external L1 addresses through their existing on-chain governance mechanisms.
+
+## Manual Verification of `ft_withdraw`
+
+The `ft_withdraw` functionality, which allows for direct withdrawal to a native chain address via a memo, was manually verified to confirm its viability beyond the automated test cases. This provides an independent confirmation of the core mechanism.
+
+The following `near-cli` command was used to withdraw ETH (represented as `eth.omft.near` on NEAR) to an Ethereum address:
+```bash
+near contract call-function as-transaction intents.near ft_withdraw json-args '{"receiver_id": "eth.omft.near", "amount": "10000000000000000", "token": "eth.omft.near", "memo": "WITHDRAW_TO:0xa029Ca6D14b97749889702eE16E7d168a1094aFE"}' prepaid-gas '100.0 Tgas' attached-deposit '1 yoctoNEAR' sign-as petersalomonsen.near network-config mainnet sign-with-keychain send
+```
+*(Replace `petersalomonsen.near` with your own NEAR account ID and `0xa029Ca6D14b97749889702eE16E7d168a1094aFE` with your desired destination address in the memo).*
+
+This resulted in the following transactions:
+*   NEAR Transaction: [https://nearblocks.io/txns/HibaVVqfuNSDUyAeoNwSv7o83Vk6eGgonmygwiGTUdK9](https://nearblocks.io/txns/HibaVVqfuNSDUyAeoNwSv7o83Vk6eGgonmygwiGTUdK9)
+*   Corresponding Ethereum Transaction: [https://etherscan.io/tx/0x87ac2955fec4f0bfb039548397343f549e5736f5207e207f1b70991d57042e35](https://etherscan.io/tx/0x87ac2955fec4f0bfb039548397343f549e5736f5207e207f1b70991d57042e35)

--- a/docs/developer/intents.md
+++ b/docs/developer/intents.md
@@ -41,3 +41,55 @@ The best way to understand how to use NEAR intents is to review and run the prov
 - Review the test files listed above to understand the deposit process and integration points.
 - Use the test code as a reference when implementing your own UI or backend logic for NEAR intents.
 - For more details on the intents contract and message formats, see the [NEAR Intents documentation](https://docs.near.org/tutorials/intents/deposit) and the comments within the test files.
+
+## How Intents-Based Payment Requests Work
+
+The `intents.near` contract can also be used to facilitate payment requests, allowing DAOs to manage and disburse assets that are under the control of the intents contract. This is particularly useful for tokens that have been bridged from other chains, as the DAO can authorize transfers of these assets using familiar NEAR proposal mechanisms.
+
+The `intents-payment-request.spec.js` test case (`playwright-tests/tests/intents/intents-payment-request.spec.js`) provides a practical example of this flow.
+
+### Process Flow for Payment Requests
+
+1.  **DAO Proposal:** A DAO member creates a proposal to transfer a certain amount of a specific token (e.g., `btc.omft.near`, which represents bridged Bitcoin) to a designated recipient.
+    *   The core of this proposal is a `FunctionCall` action targeting the `intents.near` contract.
+    *   The method called on `intents.near` is `mt_transfer`.
+    *   The arguments for `mt_transfer` include:
+        *   `token_id`: The identifier of the token to be transferred (e.g., `"nep141:btc.omft.near"`).
+        *   `amount`: The quantity of the token to send, as a string.
+        *   `receiver_id`: The NEAR account ID of the recipient.
+        *   `message` (optional): A memo for the transaction.
+
+2.  **Proposal Voting and Execution:**
+    *   DAO members vote on the proposal.
+    *   If the proposal passes, it is executed. This triggers the `mt_transfer` function call on `intents.near`.
+
+3.  **Token Transfer by `intents.near`:**
+    *   The `intents.near` contract verifies that the DAO (the caller of `mt_transfer` via the proposal) has a sufficient balance of the specified `token_id`.
+    *   If the balance is sufficient, `intents.near` updates its internal ledger to debit the DAO\\'s balance and credit the `receiver_id`\\'s balance for that token.
+
+4.  **Verification:** The recipient\\'s balance of the token, as recorded in the `intents.near` contract\\'s internal multi-token ledger, will increase. This can be verified by calling the `mt_batch_balance_of` view method on the `intents.near` contract with the recipient\\'s account ID and the token ID.
+
+### Why the Recipient Must Be a NEAR Account
+
+When `intents.near` processes a `mt_transfer` call, it is transferring ownership of tokens *that it manages on the NEAR blockchain*.
+
+*   **Internal Ledger:** The `intents.near` contract maintains an internal record of token balances for various NEAR accounts. These tokens might be native to NEAR or representations of assets bridged from other chains (like BTC or ETH).
+*   **No Native Chain Movement (Initially):** The `mt_transfer` operation within `intents.near` does *not* immediately trigger a transaction on the token\'s original native chain (e.g., the Bitcoin network for BTC). Instead, it\'s an internal accounting change within the NEAR ecosystem, specifically within the `intents.near` contract\'s state.
+*   **NEAR Account as Identifier:** Consequently, the `receiver_id` must be a valid NEAR account. This is because `intents.near` needs a NEAR-based address to credit with the tokens in its ledger.
+
+#### Limitations on Direct Cross-Chain Withdrawal via DAO Proposals
+
+A common question is why a DAO proposal cannot directly instruct `intents.near` to send tokens to an address on their native chain (e.g., a Bitcoin wallet address). The primary reasons are:
+
+1.  **Signature Requirement for Withdrawal:** Initiating a withdrawal from `intents.near` to a native chain (e.g., Bitcoin, Ethereum) requires the NEAR account holding the tokens to sign a specific withdrawal intent message. This signed message serves as authorization for the `intents.near` system to release the assets and bridge them back.
+2.  **Signed Message Publication:** This signed withdrawal intent message must then be published to the intents REST API, which coordinates the cross-chain transfer.
+3.  **DAOs Cannot Sign Messages:** SputnikDAO accounts, which are smart contracts themselves, do not possess private keys. Therefore, a DAO account cannot directly sign any message, including the required withdrawal intent.
+
+Because of this limitation, the process for a DAO to disburse assets held in `intents.near` to an external recipient on another chain involves two steps:
+
+1.  **DAO Proposal to a NEAR Account:** The DAO proposal executes an `mt_transfer` to the recipient\'s *NEAR account*. This transfers ownership of the tokens within the `intents.near` ledger.
+2.  **Recipient-Initiated Withdrawal:** After the proposal is executed, the recipient (who controls the private keys for their NEAR account) must then use a user interface or application that integrates with `intents.near` (e.g., a dedicated dashboard or wallet feature, such as [https://app.near-intents.org/](https://app.near-intents.org/)). Through this application, the recipient can sign the necessary withdrawal intent message with their NEAR account keys and submit it to initiate the transfer of assets from `intents.near` to their address on the native chain.
+
+*   **Subsequent Withdrawal:** Once a NEAR account has received tokens via `intents.near`, the owner of that account can then choose to initiate a withdrawal process. This withdrawal would involve interacting with `intents.near` (or an associated bridge contract) to move the tokens from NEAR back to their native chain (e.g., sending BTC from the intents system to an external Bitcoin wallet address). This withdrawal is a separate step from the DAO-approved payment request.
+
+This system allows DAOs on NEAR to manage and transfer a diverse range of assets efficiently using on-chain NEAR transactions, abstracting away the complexities of direct cross-chain interactions for the payment approval step.

--- a/playwright-tests/tests/intents/intents-payment-request.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request.spec.js
@@ -269,12 +269,13 @@ test("create payment request to transfer BTC", async ({ page }) => {
             receiver_id: intentsContract.accountId,
             actions: [
               {
-                method_name: "mt_transfer",
+                method_name: "ft_withdraw",
                 args: Buffer.from(
                   JSON.stringify({
-                    receiver_id: creatorAccount.accountId,
-                    token_id: tokenId,
-                    amount: 2_000_000_000_000_000_000n.toString(),
+                    token: nativeToken.near_token_id, // This is btc.omft.near
+                    receiver_id: nativeToken.near_token_id, // Should also be btc.omft.near
+                    amount: 1_000_000_000_000_000_000n.toString(),
+                    memo: "WITHDRAW_TO:bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh", // Correct: BTC address here
                   })
                 ).toString("base64"),
                 deposit: 1n.toString(),
@@ -301,14 +302,6 @@ test("create payment request to transfer BTC", async ({ page }) => {
       gas: 300_000_000_000_000n.toString(), // Ensure enough gas for voting and potential execution
     }
   );
-
-  // Check final balance of creatorAccount for the token
-  expect(
-    await intentsContract.view("mt_batch_balance_of", {
-      account_id: creatorAccount.accountId,
-      token_ids: [tokenId],
-    })
-  ).toEqual([2_000_000_000_000_000_000n.toString()]);
 
   await worker.tearDown();
 });

--- a/playwright-tests/tests/intents/intents-payment-request.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request.spec.js
@@ -7,9 +7,7 @@ import {
   SPUTNIK_DAO_FACTORY_ID,
 } from "../../util/sandboxrpc.js";
 
-test("create payment request to transfer BTC from near-intents to the requested BTC account", async ({
-  page,
-}) => {
+test("create payment request to transfer BTC", async ({ page }) => {
   test.setTimeout(120_000);
   const daoName = "testdao";
 

--- a/playwright-tests/tests/intents/intents-payment-request.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request.spec.js
@@ -1,0 +1,316 @@
+import { expect } from "@playwright/test";
+import { test } from "../../util/test.js";
+import { Account, parseNEAR, Worker } from "near-workspaces";
+import { connect } from "near-api-js";
+import {
+  PROPOSAL_BOND,
+  SPUTNIK_DAO_FACTORY_ID,
+} from "../../util/sandboxrpc.js";
+
+test("create payment request to transfer BTC from near-intents to the requested BTC account", async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+  const daoName = "testdao";
+
+  const availableTokens = (
+    await fetch("https://api-mng-console.chaindefuser.com/api/tokens").then(
+      (r) => r.json()
+    )
+  ).items;
+  const tokenId = availableTokens.find(
+    (token) => token.defuse_asset_id === "nep141:btc.omft.near"
+  ).defuse_asset_id;
+
+  const supportedTokens = await fetch("https://bridge.chaindefuser.com/rpc", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      id: "dontcare",
+      jsonrpc: "2.0",
+      method: "supported_tokens",
+      params: [
+        {
+          chains: [
+            "btc:mainnet", // Ethereum Mainnet
+          ],
+        },
+      ],
+    }),
+  }).then((r) => r.json());
+
+  const nativeToken = supportedTokens.result.tokens[0];
+  expect(nativeToken.near_token_id).toEqual("btc.omft.near");
+
+  expect(tokenId).toEqual("nep141:btc.omft.near");
+
+  const worker = await Worker.init();
+  const mainnet = await connect({
+    networkId: "mainnet",
+    nodeUrl: "https://rpc.mainnet.fastnear.com",
+  });
+
+  const omftContract = await worker.rootAccount.importContract({
+    mainnetContract: "omft.near",
+  });
+  const omftMainnetAccount = await mainnet.account(omftContract.accountId);
+
+  await omftContract.call(omftContract.accountId, "new", {
+    super_admins: ["omft.near"],
+    admins: {},
+    grantees: {
+      DAO: ["omft.near"],
+      TokenDeployer: ["omft.near"],
+      TokenDepositer: ["omft.near"],
+    },
+  });
+
+  await omftContract.call(
+    omftContract.accountId,
+    "deploy_token",
+    {
+      token: "btc",
+      metadata: await omftMainnetAccount.viewFunction({
+        contractId: nativeToken.near_token_id,
+        methodName: "ft_metadata",
+      }),
+    },
+    { attachedDeposit: parseNEAR("3"), gas: 300_000_000_000_000n.toString() }
+  );
+
+  // Import factory at the time testdao was created
+  const intentsContract = await worker.rootAccount.importContract({
+    mainnetContract: "intents.near",
+  });
+  await intentsContract.call(intentsContract.accountId, "new", {
+    config: {
+      wnear_id: "wrap.near",
+      fees: {
+        fee: 100,
+        fee_collector: "intents.near",
+      },
+      roles: {
+        super_admins: ["intents.near"],
+        admins: {},
+        grantees: {},
+      },
+    },
+  });
+
+  await omftContract.call(
+    nativeToken.near_token_id,
+    "storage_deposit",
+    {
+      account_id: intentsContract.accountId,
+      registration_only: true,
+    },
+    {
+      attachedDeposit: 1_500_0000000000_0000000000n.toString(),
+    }
+  );
+
+  // Import factory at the time testdao was created
+  const factoryContract = await worker.rootAccount.importContract({
+    mainnetContract: SPUTNIK_DAO_FACTORY_ID,
+  });
+
+  await factoryContract.call(
+    SPUTNIK_DAO_FACTORY_ID,
+    "new",
+    {},
+    { gas: 300_000_000_000_000 }
+  );
+
+  // Create testdao
+
+  const creatorAccount = await worker.rootAccount.createSubAccount(
+    "testcreator"
+  );
+
+  const create_testdao_args = {
+    name: daoName,
+    args: Buffer.from(
+      JSON.stringify({
+        config: {
+          name: daoName,
+          purpose: "creating dao treasury",
+          metadata: "",
+        },
+        policy: {
+          roles: [
+            {
+              kind: {
+                Group: [creatorAccount.accountId],
+              },
+              name: "Create Requests",
+              permissions: [
+                "call:AddProposal",
+                "transfer:AddProposal",
+                "config:Finalize",
+              ],
+              vote_policy: {},
+            },
+            {
+              kind: {
+                Group: [creatorAccount.accountId],
+              },
+              name: "Manage Members",
+              permissions: [
+                "config:*",
+                "policy:*",
+                "add_member_to_role:*",
+                "remove_member_from_role:*",
+              ],
+              vote_policy: {},
+            },
+            {
+              kind: {
+                Group: [creatorAccount.accountId],
+              },
+              name: "Vote",
+              permissions: ["*:VoteReject", "*:VoteApprove", "*:VoteRemove"],
+              vote_policy: {},
+            },
+          ],
+          default_vote_policy: {
+            weight_kind: "RoleWeight",
+            quorum: "0",
+            threshold: [1, 2],
+          },
+          proposal_bond: PROPOSAL_BOND,
+          proposal_period: "604800000000000",
+          bounty_bond: "100000000000000000000000",
+          bounty_forgiveness_period: "604800000000000",
+        },
+      })
+    ).toString("base64"),
+  };
+
+  await creatorAccount.call(
+    SPUTNIK_DAO_FACTORY_ID,
+    "create",
+    create_testdao_args,
+    {
+      gas: 300_000_000_000_000,
+      attachedDeposit: parseNEAR("6"),
+    }
+  );
+
+  const daoAccount = new Account(`${daoName}.${SPUTNIK_DAO_FACTORY_ID}`);
+
+  // Available tokens: https://api-mng-console.chaindefuser.com/api/tokens
+
+  const depositAddress = (
+    await fetch("https://bridge.chaindefuser.com/rpc", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "dontcare",
+        method: "deposit_address",
+        params: [
+          {
+            account_id: daoAccount,
+            chain: "btc:mainnet", // CHAIN_TYPE:CHAIN_ID
+          },
+        ],
+      }),
+    }).then((r) => r.json())
+  ).result.address;
+
+  expect(depositAddress).toEqual("1JBmcrzAPeAeQA9CRAuYEoKSE6RN8hu59x");
+
+  await omftContract.call(
+    omftContract.accountId,
+    "ft_deposit",
+    {
+      owner_id: "intents.near",
+      token: "btc",
+      amount: 32_000_000_000_000_000_000n.toString(),
+      msg: JSON.stringify({ receiver_id: daoAccount }),
+      memo: `BRIDGED_FROM:${JSON.stringify({
+        networkType: "btc",
+        chainId: "1",
+        txHash:
+          "0xc6b7ecd5c7517a8f56ac7ec9befed7d26a459fc97c7d5cd7598d4e19b5a806b7",
+      })}`,
+    },
+    {
+      attachedDeposit: parseNEAR("0.00125"),
+      gas: 300_000_000_000_000n.toString(),
+    }
+  );
+
+  expect(
+    await intentsContract.view("mt_batch_balance_of", {
+      account_id: daoAccount.accountId,
+      token_ids: [tokenId],
+    })
+  ).toEqual([32_000_000_000_000_000_000n.toString()]);
+
+  // Check initial balance of creatorAccount for the token
+  expect(
+    await intentsContract.view("mt_batch_balance_of", {
+      account_id: creatorAccount.accountId,
+      token_ids: [tokenId],
+    })
+  ).toEqual(["0"]);
+
+  const proposalId = await creatorAccount.call(
+    daoAccount.accountId,
+    "add_proposal",
+    {
+      proposal: {
+        description: "Transfer BTC",
+        kind: {
+          FunctionCall: {
+            receiver_id: intentsContract.accountId,
+            actions: [
+              {
+                method_name: "mt_transfer",
+                args: Buffer.from(
+                  JSON.stringify({
+                    receiver_id: creatorAccount.accountId,
+                    token_id: tokenId,
+                    amount: 2_000_000_000_000_000_000n.toString(),
+                  })
+                ).toString("base64"),
+                deposit: 1n.toString(),
+                gas: 30_000_000_000_000n.toString(),
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      attachedDeposit: PROPOSAL_BOND,
+    }
+  );
+
+  await creatorAccount.call(
+    daoAccount.accountId,
+    "act_proposal",
+    {
+      id: proposalId,
+      action: "VoteApprove",
+    },
+    {
+      gas: 300_000_000_000_000n.toString(), // Ensure enough gas for voting and potential execution
+    }
+  );
+
+  // Check final balance of creatorAccount for the token
+  expect(
+    await intentsContract.view("mt_batch_balance_of", {
+      account_id: creatorAccount.accountId,
+      token_ids: [tokenId],
+    })
+  ).toEqual([2_000_000_000_000_000_000n.toString()]);
+
+  await worker.tearDown();
+});

--- a/playwright-tests/tests/intents/intents-payment-request.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request.spec.js
@@ -8,10 +8,12 @@ import {
 } from "../../util/sandboxrpc.js";
 
 /**
- * The approach here was verified in the following transactions
+ * The approach of calling `ft_withdraw`was verified manually like this.
+ * near contract call-function as-transaction intents.near ft_withdraw json-args '{"receiver_id": "eth.omft.near", "amount": "10000000000000000", "token": "eth.omft.near", "memo": "WITHDRAW_TO:0xa029Ca6D14b97749889702eE16E7d168a1094aFE"}' prepaid-gas '100.0 Tgas' attached-deposit '1 yoctoNEAR' sign-as petersalomonsen.near network-config mainnet sign-with-keychain send
  *
- * https://etherscan.io/tx/0x87ac2955fec4f0bfb039548397343f549e5736f5207e207f1b70991d57042e35
- * https://nearblocks.io/txns/HibaVVqfuNSDUyAeoNwSv7o83Vk6eGgonmygwiGTUdK9
+ * It resulted in this transaction on NEAR: https://nearblocks.io/txns/HibaVVqfuNSDUyAeoNwSv7o83Vk6eGgonmygwiGTUdK9
+ * And finally this on ETH: https://etherscan.io/tx/0x87ac2955fec4f0bfb039548397343f549e5736f5207e207f1b70991d57042e35
+ *
  */
 test("create payment request to transfer BTC", async ({ page }) => {
   test.setTimeout(120_000);


### PR DESCRIPTION
**Subject: Tests & Docs: DAO Payment Intents via `ft_withdraw`**

This PR introduces foundational tests and documentation in preparation for implementing DAO payment requests (withdrawals) as described in issue #493. It also resolves issue #491 by explaining the intents-based payment request mechanism.

**Key contributions:**

*   **New Playwright Test (`playwright-tests/tests/intents/intents-payment-request.spec.js`):**
    *   Demonstrates how a DAO can propose and execute a withdrawal of assets to a native L1 chain address.
    *   Utilizes the `ft_withdraw` method on the `intents.near` contract, with the destination L1 address specified in the `memo` field.
    *   This test serves as a working example and a validation of the withdrawal flow.

*   **Documentation Update (`docs/developer/intents.md`):**
    *   Added a new section "How Intents-Based Payment Requests Work," detailing the `ft_withdraw` approach for DAOs.
    *   Clarified that direct L1 withdrawals are possible via a DAO proposal targeting `intents.near`'s `ft_withdraw` method.
    *   Included a "Manual Verification of `ft_withdraw`" section with a `near-cli` command example (recently corrected for proper escaping) and links to example transactions on NEAR and Ethereum, confirming the mechanism.

This PR does not introduce new application functionality but lays the critical groundwork for issue #493 by providing robust testing and accurate documentation for the `ft_withdraw` based withdrawal process.

resolves #491