### PR TITLE
Use FastNEAR RPC for web4

### DIFF
--- a/playwright-tests/util/web3icon.js
+++ b/playwright-tests/util/web3icon.js
@@ -54,6 +54,7 @@ export async function getWeb3IconMaps() {
         );
 
       const tokenSvg = svgs.tokens.background[web3IconToken.fileName].default;
+
       const networkSvg = web3IconNetwork
         ? svgs.networks.background[web3IconNetwork.fileName].default
         : null;
@@ -63,10 +64,13 @@ export async function getWeb3IconMaps() {
 
       if (tokenSvg) {
         tokenIconMap[token.asset_name] = tokenSvg;
+      }
+      if (networkSvg) {
         networkIconMap[blockchain] = networkSvg;
+      }
+      if (networkName) {
         networkNames[blockchain] = networkName;
       }
-    } else {
     }
   }
 

--- a/web4/public_html/index.html
+++ b/web4/public_html/index.html
@@ -828,6 +828,7 @@
     if (location.host.endsWith(".page")) {
       const instanceAccount = location.host.split(".")[0];
       viewer.setAttribute("src", `${instanceAccount}.near/widget/app`);
+      viewer.setAttribute("rpc", "https://rpc.mainnet.fastnear.com");
     } else if (location.port === "8080") {
       viewer.setAttribute("rpc", "http://127.0.0.1:14500");
     }


### PR DESCRIPTION
This PR will publish a new web4 contract using FastNEAR RPC. After the treasury factory is updated, a system update should be published so that instances can be upgraded.

The effect of changing to FastNEAR can be observed here: https://webassemblymusic-treasury.near.page/
Note that while other treasury4 web4 pages reach the rate limit on the second page reload, it takes a bit more page navigations to reach it with the upgraded instance.

Changes:

- set `rpc` attribute of the web4 `near-social-viewer` component to `https://rpc.mainnet.fastnear.com`
- `redirectWeb4` test handler to also route requests to fastnear ( since existing tests assumes that web4 still use near.org RPC )
- Fix logo intents test failing since it is not mapping network tokens without icons ( which apply to many of the tokens on NEAR )

fixes #566 