### PR TITLE
feat: Add network info, fees, and transaction links for NEAR Intents payments

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/components/TokenAmountAndIcon.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/TokenAmountAndIcon.jsx
@@ -26,7 +26,7 @@ if (isWrapNear) {
 
 if (!isNEAR && !isWrapNear) {
   ftMetadata = Near.view(address, "ft_metadata", {});
-  if (ftMetadata === null) return null;
+  if (ftMetadata === null) return <></>;
 }
 
 let amount = amountWithDecimals;

--- a/instances/widgets.treasury-factory.near/widget/components/Web3IconFetcher.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/Web3IconFetcher.jsx
@@ -56,6 +56,7 @@ const generateEnhancedIconHTML = () => {
         
         let tokenIcon = null;
         let networkIcon = null;
+        let networkName = null;
         
         // Find token in web3icons metadata
         const web3IconToken = web3IconsCommon.tokens.find(t => 
@@ -98,6 +99,7 @@ const generateEnhancedIconHTML = () => {
           
           if (web3IconNetwork && web3IconsCore.svgs.networks.background[web3IconNetwork.fileName]) {
             networkIcon = web3IconsCore.svgs.networks.background[web3IconNetwork.fileName].default;
+            networkName = web3IconNetwork.name;
           }
         }
         
@@ -106,6 +108,7 @@ const generateEnhancedIconHTML = () => {
         results[key] = {
           tokenIcon: tokenIcon ? \`data:image/svg+xml;base64,\${btoa(tokenIcon)}\` : null,
           networkIcon: networkIcon ? \`data:image/svg+xml;base64,\${btoa(networkIcon)}\` : null,
+          networkName,
           symbol: symbol,
           networkId: networkId,
         };

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
@@ -650,7 +650,7 @@ return (
                           href={transactionInfo.nearTxHash}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="btn btn-outline-primary btn-sm d-flex align-items-center gap-2"
+                          className="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
                           style={{ width: "fit-content" }}
                         >
                           View execution on nearblocks.io{" "}

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
@@ -643,32 +643,34 @@ return (
                   )}
                 {proposalData?.status === "Approved" &&
                   transactionInfo.nearTxHash && (
-                    <div className="d-flex flex-column gap-2 mt-3">
+                    <div className="d-flex flex-column gap-2 mt-1">
                       <label className="border-top">Transaction Links</label>
                       <div className="d-flex flex-column gap-2">
-                        <a
-                          href={transactionInfo.nearTxHash}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
-                          style={{ width: "fit-content" }}
-                        >
-                          View execution on nearblocks.io{" "}
-                          <i className="bi bi-box-arrow-up-right"></i>
-                        </a>
-                        {transactionInfo.targetTxHash && (
+                        <div className="d-flex justify-content-between gap-2 align-items-center flex-wrap">
                           <a
-                            href={transactionInfo.targetTxHash}
+                            href={transactionInfo.nearTxHash}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
-                            style={{ width: "fit-content" }}
+                            className="d-flex align-items-center gap-2"
                           >
-                            {getExplorerButtonText(
-                              transactionInfo.targetTxHash
-                            )}{" "}
+                            View execution on nearblocks.io{" "}
                             <i className="bi bi-box-arrow-up-right"></i>
                           </a>
+                        </div>
+                        {transactionInfo.targetTxHash && (
+                          <div className="d-flex justify-content-between gap-2 align-items-center flex-wrap">
+                            <a
+                              href={transactionInfo.targetTxHash}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="d-flex align-items-center gap-2"
+                            >
+                              {getExplorerButtonText(
+                                transactionInfo.targetTxHash
+                              )}{" "}
+                              <i className="bi bi-box-arrow-up-right"></i>
+                            </a>
+                          </div>
                         )}
                       </div>
                     </div>

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
@@ -357,7 +357,12 @@ useEffect(() => {
 
       // Query NearBlocks API for on_proposal_callback transactions
       asyncFetch(
-        `https://api.nearblocks.io/v1/account/${treasuryDaoID}/receipts?method=on_proposal_callback&after_date=${afterDate}&before_date=${beforeDate}`
+        `https://api.nearblocks.io/v1/account/${treasuryDaoID}/receipts?method=on_proposal_callback&after_date=${afterDate}&before_date=${beforeDate}`,
+        {
+          headers: {
+            Authorization: "Bearer ${REPL_NEARBLOCKS_KEY}",
+          },
+        }
       )
         .then((response) => {
           if (!response.ok || !response.body?.txns) {

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
@@ -422,6 +422,19 @@ function checkProposalStatus(proposalId) {
     });
 }
 
+function getExplorerButtonText(url) {
+  try {
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname;
+    const actionText = url.includes('/tx/') ? 'View transfer' : 'View address';
+    return `${actionText} on ${hostname}`;
+  } catch (e) {
+    // Fallback if URL parsing fails
+    const actionText = url.includes('/tx/') ? 'View transfer' : 'View address';
+    return `${actionText} on target explorer`;
+  }
+}
+
 return (
   <>
     {networkInfo.blockchain && proposalData?.isIntentsPayment && (
@@ -567,7 +580,7 @@ return (
                     className="btn btn-outline-primary btn-sm d-flex align-items-center gap-2"
                     style={{ width: "fit-content" }}
                   >
-                    {transactionInfo.nearTxHash.includes('/txns/') ? 'View Execution' : 'Search Execution'} on NEAR Blocks <i className="bi bi-box-arrow-up-right"></i>
+                    {transactionInfo.nearTxHash.includes('/txns/') ? 'View execution' : 'Search execution'} on nearblocks.io <i className="bi bi-box-arrow-up-right"></i>
                   </a>
                   {transactionInfo.targetTxHash && (
                     <a
@@ -577,7 +590,7 @@ return (
                       className="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
                       style={{ width: "fit-content" }}
                     >
-                      {transactionInfo.targetTxHash.includes('/tx/') ? 'View Transfer' : 'View Address'} on {networkInfo.blockchain?.toUpperCase()} Explorer <i className="bi bi-box-arrow-up-right"></i>
+                      {getExplorerButtonText(transactionInfo.targetTxHash)} <i className="bi bi-box-arrow-up-right"></i>
                     </a>
                   )}
                 </div>

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
@@ -288,7 +288,8 @@ useEffect(() => {
 useEffect(() => {
   if (
     proposalData?.isIntentsPayment &&
-    proposalData?.status === "Approved" &&
+    (proposalData?.status === "Approved" ||
+      proposalData?.status === "Failed") &&
     networkInfo.blockchain &&
     networkInfo.blockchain !== "near" &&
     transactionInfo.nearTxHash &&
@@ -368,7 +369,8 @@ useEffect(() => {
 // Fetch execution transaction hash for approved proposals
 useEffect(() => {
   if (
-    proposalData?.status === "Approved" &&
+    (proposalData?.status === "Approved" ||
+      proposalData?.status === "Failed") &&
     proposalData?.submissionTime &&
     proposalPeriod
   ) {
@@ -651,7 +653,8 @@ return (
                       </div>
                     </div>
                   )}
-                {proposalData?.status === "Approved" &&
+                {(proposalData?.status === "Approved" ||
+                  proposalData?.status === "Failed") &&
                   transactionInfo.nearTxHash && (
                     <div className="d-flex flex-column gap-2 mt-1">
                       <label className="border-top">Transaction Links</label>

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
@@ -503,6 +503,16 @@ function getExplorerButtonText(url) {
   }
 }
 
+const TransactionLink = styled.a`
+  color: var(--text-color) !important;
+  text-decoration: underline !important;
+
+  &:hover {
+    color: inherit !important;
+    text-decoration: none !important;
+  }
+`;
+
 return (
   <>
     {((proposalData && !proposalData.isIntentsPayment) ||
@@ -647,7 +657,7 @@ return (
                       <label className="border-top">Transaction Links</label>
                       <div className="d-flex flex-column gap-2">
                         <div className="d-flex justify-content-between gap-2 align-items-center flex-wrap">
-                          <a
+                          <TransactionLink
                             href={transactionInfo.nearTxHash}
                             target="_blank"
                             rel="noopener noreferrer"
@@ -655,11 +665,11 @@ return (
                           >
                             View execution on nearblocks.io{" "}
                             <i className="bi bi-box-arrow-up-right"></i>
-                          </a>
+                          </TransactionLink>
                         </div>
                         {transactionInfo.targetTxHash && (
                           <div className="d-flex justify-content-between gap-2 align-items-center flex-wrap">
-                            <a
+                            <TransactionLink
                               href={transactionInfo.targetTxHash}
                               target="_blank"
                               rel="noopener noreferrer"
@@ -669,7 +679,7 @@ return (
                                 transactionInfo.targetTxHash
                               )}{" "}
                               <i className="bi bi-box-arrow-up-right"></i>
-                            </a>
+                            </TransactionLink>
                           </div>
                         )}
                       </div>

--- a/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/payments/ProposalDetailsPage.jsx
@@ -227,25 +227,7 @@ useEffect(() => {
   }
 }, [proposalData?.isIntentsPayment, networkInfo.blockchain]);
 
-// Set target network explorer links for approved intents payments
-useEffect(() => {
-  if (proposalData?.isIntentsPayment && proposalData?.status === "Approved" && 
-      networkInfo.blockchain && networkInfo.blockchain !== "near") {
-    // For target network explorers - initially set to recipient address
-    let targetExplorerLink = null;
-    if (networkInfo.blockchain === "eth") {
-      // For Ethereum, link to the recipient address on Etherscan as fallback
-      if (proposalData.intentsTokenInfo?.realRecipient) {
-        targetExplorerLink = `https://etherscan.io/address/${proposalData.intentsTokenInfo.realRecipient}`;
-      }
-    }
-    
-    setTransactionInfo(prev => ({
-      ...prev,
-      targetTxHash: targetExplorerLink,
-    }));
-  }
-}, [proposalData?.isIntentsPayment, proposalData?.status, networkInfo.blockchain, proposalData?.intentsTokenInfo]);
+// Note: No fallback target network explorer links - only show actual transaction links
 
 // Fetch target chain transaction hash for approved intents payments
 useEffect(() => {
@@ -338,11 +320,6 @@ useEffect(() => {
       ).then((response) => {
         if (!response.ok || !response.body?.txns) {
           console.log("No execution transactions found or API error");
-          // Fallback to a generic search link
-          setTransactionInfo(prev => ({
-            ...prev,
-            nearTxHash: `https://nearblocks.io/address/${treasuryDaoID}?tab=txns&method=on_proposal_callback`,
-          }));
           return;
         }
         
@@ -366,19 +343,9 @@ useEffect(() => {
           }));
         } else {
           console.log(`No execution transaction found for proposal ${proposalData.id}`);
-          // Fallback to a generic search link
-          setTransactionInfo(prev => ({
-            ...prev,
-            nearTxHash: `https://nearblocks.io/address/${treasuryDaoID}?tab=txns&method=on_proposal_callback`,
-          }));
         }
       }).catch((error) => {
         console.error("Error fetching execution transaction:", error);
-        // Fallback to a generic search link
-        setTransactionInfo(prev => ({
-          ...prev,
-          nearTxHash: `https://nearblocks.io/address/${treasuryDaoID}?tab=txns&method=on_proposal_callback`,
-        }));
       });
     };
     
@@ -580,7 +547,7 @@ return (
                     className="btn btn-outline-primary btn-sm d-flex align-items-center gap-2"
                     style={{ width: "fit-content" }}
                   >
-                    {transactionInfo.nearTxHash.includes('/txns/') ? 'View execution' : 'Search execution'} on nearblocks.io <i className="bi bi-box-arrow-up-right"></i>
+                    View execution on nearblocks.io <i className="bi bi-box-arrow-up-right"></i>
                   </a>
                   {transactionInfo.targetTxHash && (
                     <a

--- a/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
@@ -56,8 +56,13 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
   await expect(nearBlocksButton).toBeVisible();
   
   // Check for the specific transaction link to the actual execution transaction
-  // Now that the API lookup is working, we should get the specific transaction hash
   await expect(page.locator('a[href*="nearblocks.io/txns/2trLm2bSSFiUDt2xckM3UW6C6BND4iksiqEihaEjtcbC"]')).toBeVisible();
+  
+  // Wait a bit more for the target chain transaction to be fetched
+  await page.waitForTimeout(2000);
+  
+  // Check for target chain transaction link (Ethereum in this case)
+  await expect(page.locator('a[href*="etherscan.io/tx/0x8f52efccdccc3bddc82abc15e259b3d1671959a9694f09d20276892a5863e8d6"]')).toBeVisible();
   
   // Take a screenshot to see the final result
   await page.screenshot({ path: 'test-results/intents-payment-detail-final.png', fullPage: true });
@@ -67,6 +72,14 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
   const modifiedWidgets = {};
+  
+  // Capture browser console logs
+  page.on('console', msg => {
+    if (msg.type() === 'log' || msg.type() === 'error') {
+      console.log(`Browser ${msg.type()}: ${msg.text()}`);
+    }
+  });
+  
   await redirectWeb4({
     page,
     contractId: instanceAccount,
@@ -86,12 +99,38 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
       'div[data-component="widgets.treasury-factory.near/widget/components.TokenAmountAndIcon"]'
     )
   ).toContainText("0.2 wNEAR");
+  
+  // Wait for network info to load
+  await page.waitForTimeout(3000);
+  
+  // Check that network information is displayed for intents payments
+  await expect(page.locator('text=Network')).toBeVisible();
+  
+  // Check for transaction links section (should be present for approved proposals)
+  await expect(page.locator('text=Payment Request Funded')).toBeVisible();
+  await expect(page.locator('text=Transaction Links')).toBeVisible();
+  
+  // Check for NEAR Blocks link
+  const nearBlocksButton = page.locator('a:has-text("on NEAR Blocks")');
+  await expect(nearBlocksButton).toBeVisible();
+  
+  // For NEAR-to-NEAR intents payments, target chain transaction link should NOT be shown
+  const targetTxLink = page.locator('a:has-text("Explorer"):not(:has-text("NEAR Blocks"))');
+  await expect(targetTxLink).not.toBeVisible();
+  console.log('SUCCESS: Target chain transaction link correctly hidden for NEAR payment');
 });
 
 test("Regular payment request shows transaction links", async ({ page }) => {
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
   const modifiedWidgets = {};
+  
+  // Capture browser console logs
+  page.on('console', msg => {
+    if (msg.type() === 'log' || msg.type() === 'error') {
+      console.log(`Browser ${msg.type()}: ${msg.text()}`);
+    }
+  });
   
   await redirectWeb4({
     page,
@@ -103,22 +142,26 @@ test("Regular payment request shows transaction links", async ({ page }) => {
   });
   
   // Navigate to a regular (non-intents) approved payment request
-  // Using id=1 which should be a regular payment if it exists
+  // Using id=8 which is confirmed to be a regular (non-intents) payment
   await page.goto(
-    "https://webassemblymusic-treasury.near.page/?page=payments&tab=history&id=1"
+    "https://webassemblymusic-treasury.near.page/?page=payments&tab=history&id=8"
   );
   
   // Wait for the page to load
   await page.waitForTimeout(3000);
   
-  // Check if this is an approved proposal - if not, skip the transaction links check
-  const statusElement = page.locator('text=Payment Request Funded');
-  if (await statusElement.isVisible()) {
-    // Check for transaction links section (should be present for all approved proposals)
-    await expect(page.locator('text=Transaction Links')).toBeVisible();
-    
-    // Check for NEAR Blocks link (either "View Execution" or "Search Execution")
-    const nearBlocksButton = page.locator('a:has-text("on NEAR Blocks")');
-    await expect(nearBlocksButton).toBeVisible();
-  }
+  // Check that this is an approved proposal and verify transaction links
+  await expect(page.locator('text=Payment Request Funded')).toBeVisible();
+  
+  // Check for transaction links section (should be present for all approved proposals)
+  await expect(page.locator('text=Transaction Links')).toBeVisible();
+  
+  // Check for NEAR Blocks link (either "View Execution" or "Search Execution")
+  const nearBlocksButton = page.locator('a:has-text("on NEAR Blocks")');
+  await expect(nearBlocksButton).toBeVisible();
+  
+  // For regular (non-intents) payments, target chain transaction link should NOT be shown
+  const targetTxLink = page.locator('a:has-text("Explorer"):not(:has-text("NEAR Blocks"))');
+  await expect(targetTxLink).not.toBeVisible();
+  console.log('SUCCESS: Target chain transaction link correctly hidden for regular payment');
 });

--- a/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
@@ -56,7 +56,7 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
   await expect(page.locator("text=Network")).toBeVisible();
   // Look for the network name specifically under the Network label
   await expect(
-    page.locator("span.text-capitalize").filter({ hasText: "eth" })
+    page.locator("span.text-capitalize").filter({ hasText: "Ethereum" })
   ).toBeVisible();
 
   // Check for fee information (if present)
@@ -137,6 +137,9 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
 
   // Check that network information is displayed for intents payments
   await expect(page.locator("text=Network")).toBeVisible();
+  await expect(
+    page.locator("span.text-capitalize").filter({ hasText: "Near Protocol" })
+  ).toBeVisible();
 
   // Check for transaction links section - this should always be present for approved proposals
   await expect(page.locator("text=Payment Request Funded")).toBeVisible();
@@ -201,9 +204,9 @@ test("Regular payment request shows transaction links", async ({ page }) => {
 
   // Check for transaction links section - this should always be present for approved proposals
   await expect(page.locator("text=Payment Request Funded")).toBeVisible();
-  await expect(
-    page.locator('label:has-text("Transaction Links")')
-  ).toBeVisible();
+  await expect(page.locator('label:has-text("Transaction Links")')).toBeVisible(
+    { timeout: 15_000 }
+  );
 
   // Check for NEAR Blocks link
   const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');

--- a/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
@@ -123,14 +123,20 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
   await page.goto(
     "https://webassemblymusic-treasury.near.page/?page=payments&tab=history&id=4"
   );
-  await expect(page.getByText("Recipient Peter Salomonsen @")).toContainText(
-    "petersalomonsen.near"
-  );
   await expect(
     page.locator(
       'div[data-component="widgets.treasury-factory.near/widget/components.TokenAmountAndIcon"]'
     )
   ).toContainText("0.2 wNEAR");
+
+  const recipientArea = page.getByText("Recipient Peter Salomonsen @");
+  await expect(recipientArea).toBeVisible();
+  await expect(recipientArea).toContainText("petersalomonsen.near");
+  await expect(
+    recipientArea.locator(
+      'img[src="https://i.near.social/magic/large/https://near.social/magic/img/account/petersalomonsen.near"]'
+    )
+  ).toBeVisible();
 
   // Wait for network info to load
   await page.waitForTimeout(3000);
@@ -157,16 +163,13 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
   );
   await expect(targetTxLink).not.toBeVisible();
 
-  // Verify that no fallback transaction links are shown
-  await expect(
-    page.locator('a:has-text("Search execution")')
-  ).not.toBeVisible();
-
   console.log(
     "SUCCESS: Target chain transaction link correctly hidden for NEAR payment"
   );
 
-  await page.waitForTimeout(500);
+  // grabbing screenshots is needed to ensure all elements are rendered on the video
+  await page.screenshot({ fullPage: true });
+  await page.waitForTimeout(1000);
 });
 
 test("Regular payment request shows transaction links", async ({ page }) => {
@@ -196,6 +199,15 @@ test("Regular payment request shows transaction links", async ({ page }) => {
     "https://webassemblymusic-treasury.near.page/?page=payments&tab=history&id=8"
   );
 
+  const recipientArea = page.getByText("Recipient Peter Salomonsen @");
+  await expect(recipientArea).toBeVisible();
+  await expect(recipientArea).toContainText("petersalomonsen.near");
+  await expect(
+    recipientArea.locator(
+      'img[src="https://i.near.social/magic/large/https://near.social/magic/img/account/petersalomonsen.near"]'
+    )
+  ).toBeVisible();
+
   // Wait for the page to load
   await page.waitForTimeout(3000);
 
@@ -218,14 +230,11 @@ test("Regular payment request shows transaction links", async ({ page }) => {
   );
   await expect(targetTxLink).not.toBeVisible();
 
-  // Verify that no fallback transaction links are shown
-  await expect(
-    page.locator('a:has-text("Search execution")')
-  ).not.toBeVisible();
-
   console.log(
     "SUCCESS: Target chain transaction link correctly hidden for regular payment"
   );
 
-  await page.waitForTimeout(500);
+  // grabbing screenshots is needed to ensure all elements are rendered on the video
+  await page.screenshot({ fullPage: true });
+  await page.waitForTimeout(1000);
 });

--- a/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
@@ -51,8 +51,8 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
   // Check for transaction links section (should be present for all approved proposals)
   await expect(page.locator('text=Transaction Links')).toBeVisible();
   
-  // Check for NEAR Blocks link (either "View Execution" or "Search Execution")
-  const nearBlocksButton = page.locator('a:has-text("on NEAR Blocks")');
+  // Check for NEAR Blocks link (either "View execution" or "Search execution")
+  const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');
   await expect(nearBlocksButton).toBeVisible();
   
   // Check for the specific transaction link to the actual execution transaction
@@ -111,11 +111,11 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
   await expect(page.locator('text=Transaction Links')).toBeVisible();
   
   // Check for NEAR Blocks link
-  const nearBlocksButton = page.locator('a:has-text("on NEAR Blocks")');
+  const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');
   await expect(nearBlocksButton).toBeVisible();
   
   // For NEAR-to-NEAR intents payments, target chain transaction link should NOT be shown
-  const targetTxLink = page.locator('a:has-text("Explorer"):not(:has-text("NEAR Blocks"))');
+  const targetTxLink = page.locator('a:has-text("on etherscan.io"), a:has-text("on polygonscan.com"), a:has-text("on bscscan.com")');
   await expect(targetTxLink).not.toBeVisible();
   console.log('SUCCESS: Target chain transaction link correctly hidden for NEAR payment');
 });
@@ -156,12 +156,12 @@ test("Regular payment request shows transaction links", async ({ page }) => {
   // Check for transaction links section (should be present for all approved proposals)
   await expect(page.locator('text=Transaction Links')).toBeVisible();
   
-  // Check for NEAR Blocks link (either "View Execution" or "Search Execution")
-  const nearBlocksButton = page.locator('a:has-text("on NEAR Blocks")');
+  // Check for NEAR Blocks link (either "View execution" or "Search execution")
+  const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');
   await expect(nearBlocksButton).toBeVisible();
   
   // For regular (non-intents) payments, target chain transaction link should NOT be shown
-  const targetTxLink = page.locator('a:has-text("Explorer"):not(:has-text("NEAR Blocks"))');
+  const targetTxLink = page.locator('a:has-text("on etherscan.io"), a:has-text("on polygonscan.com"), a:has-text("on bscscan.com")');
   await expect(targetTxLink).not.toBeVisible();
   console.log('SUCCESS: Target chain transaction link correctly hidden for regular payment');
 });

--- a/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
@@ -6,14 +6,14 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
   const modifiedWidgets = {};
-  
+
   // Capture browser console logs
-  page.on('console', msg => {
-    if (msg.type() === 'log' || msg.type() === 'error') {
+  page.on("console", (msg) => {
+    if (msg.type() === "log" || msg.type() === "error") {
       console.log(`Browser ${msg.type()}: ${msg.text()}`);
     }
   });
-  
+
   await redirectWeb4({
     page,
     contractId: instanceAccount,
@@ -33,56 +33,73 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
       'div[data-component="widgets.treasury-factory.near/widget/components.TokenAmountAndIcon"]'
     )
   ).toContainText("0.005 ETH");
-  
+
   // Wait for network info to load
   await page.waitForTimeout(3000);
-  
+
   // Check that network information is displayed for intents payments
-  await expect(page.locator('text=Network')).toBeVisible();
+  await expect(page.locator("text=Network")).toBeVisible();
   // Look for the network name specifically under the Network label
-  await expect(page.locator('span.text-capitalize').filter({ hasText: 'eth' })).toBeVisible();
-  
+  await expect(
+    page.locator("span.text-capitalize").filter({ hasText: "eth" })
+  ).toBeVisible();
+
   // Check for fee information (if present)
-  const feeSection = page.locator('text=Network Fee');
+  const feeSection = page.locator("text=Network Fee");
   if (await feeSection.isVisible()) {
     await expect(feeSection).toBeVisible();
   }
-  
+
   // Check for transaction links section - this should always be present for approved proposals
-  await expect(page.locator('label:has-text("Transaction Links")')).toBeVisible();
-  
+  await expect(
+    page.locator('label:has-text("Transaction Links")')
+  ).toBeVisible();
+
   // Check for NEAR Blocks link
   const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');
   await expect(nearBlocksButton).toBeVisible();
-  
+
   // Check for the specific transaction link to the actual execution transaction
-  await expect(page.locator('a[href*="nearblocks.io/txns/2trLm2bSSFiUDt2xckM3UW6C6BND4iksiqEihaEjtcbC"]')).toBeVisible();
-  
+  await expect(
+    page.locator(
+      'a[href*="nearblocks.io/txns/2trLm2bSSFiUDt2xckM3UW6C6BND4iksiqEihaEjtcbC"]'
+    )
+  ).toBeVisible();
+
   // Wait a bit more for the target chain transaction to be fetched
   await page.waitForTimeout(2000);
-  
+
   // Check for target chain transaction link (Ethereum in this case)
-  await expect(page.locator('a[href*="etherscan.io/tx/0x8f52efccdccc3bddc82abc15e259b3d1671959a9694f09d20276892a5863e8d6"]')).toBeVisible();
-  
+  await expect(
+    page.locator(
+      'a[href*="etherscan.io/tx/0x8f52efccdccc3bddc82abc15e259b3d1671959a9694f09d20276892a5863e8d6"]'
+    )
+  ).toBeVisible();
+
   // Verify that no fallback transaction links are shown
-  await expect(page.locator('a:has-text("Search execution")')).not.toBeVisible();
-  
+  await expect(
+    page.locator('a:has-text("Search execution")')
+  ).not.toBeVisible();
+
   // Take a screenshot to see the final result
-  await page.screenshot({ path: 'test-results/intents-payment-detail-final.png', fullPage: true });
+  await page.screenshot({
+    path: "test-results/intents-payment-detail-final.png",
+    fullPage: true,
+  });
 });
 
 test("NEAR Intents payment request for NEAR", async ({ page }) => {
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
   const modifiedWidgets = {};
-  
+
   // Capture browser console logs
-  page.on('console', msg => {
-    if (msg.type() === 'log' || msg.type() === 'error') {
+  page.on("console", (msg) => {
+    if (msg.type() === "log" || msg.type() === "error") {
       console.log(`Browser ${msg.type()}: ${msg.text()}`);
     }
   });
-  
+
   await redirectWeb4({
     page,
     contractId: instanceAccount,
@@ -102,43 +119,51 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
       'div[data-component="widgets.treasury-factory.near/widget/components.TokenAmountAndIcon"]'
     )
   ).toContainText("0.2 wNEAR");
-  
+
   // Wait for network info to load
   await page.waitForTimeout(3000);
-  
+
   // Check that network information is displayed for intents payments
-  await expect(page.locator('text=Network')).toBeVisible();
-  
+  await expect(page.locator("text=Network")).toBeVisible();
+
   // Check for transaction links section - this should always be present for approved proposals
-  await expect(page.locator('text=Payment Request Funded')).toBeVisible();
-  await expect(page.locator('label:has-text("Transaction Links")')).toBeVisible();
-  
+  await expect(page.locator("text=Payment Request Funded")).toBeVisible();
+  await expect(
+    page.locator('label:has-text("Transaction Links")')
+  ).toBeVisible();
+
   // Check for NEAR Blocks link
   const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');
   await expect(nearBlocksButton).toBeVisible();
-  
+
   // For NEAR-to-NEAR intents payments, target chain transaction link should NOT be shown
-  const targetTxLink = page.locator('a:has-text("on etherscan.io"), a:has-text("on polygonscan.com"), a:has-text("on bscscan.com")');
+  const targetTxLink = page.locator(
+    'a:has-text("on etherscan.io"), a:has-text("on polygonscan.com"), a:has-text("on bscscan.com")'
+  );
   await expect(targetTxLink).not.toBeVisible();
-  
+
   // Verify that no fallback transaction links are shown
-  await expect(page.locator('a:has-text("Search execution")')).not.toBeVisible();
-  
-  console.log('SUCCESS: Target chain transaction link correctly hidden for NEAR payment');
+  await expect(
+    page.locator('a:has-text("Search execution")')
+  ).not.toBeVisible();
+
+  console.log(
+    "SUCCESS: Target chain transaction link correctly hidden for NEAR payment"
+  );
 });
 
 test("Regular payment request shows transaction links", async ({ page }) => {
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
   const modifiedWidgets = {};
-  
+
   // Capture browser console logs
-  page.on('console', msg => {
-    if (msg.type() === 'log' || msg.type() === 'error') {
+  page.on("console", (msg) => {
+    if (msg.type() === "log" || msg.type() === "error") {
       console.log(`Browser ${msg.type()}: ${msg.text()}`);
     }
   });
-  
+
   await redirectWeb4({
     page,
     contractId: instanceAccount,
@@ -147,33 +172,41 @@ test("Regular payment request shows transaction links", async ({ page }) => {
     modifiedWidgets,
     callWidgetNodeURLForContractWidgets: false,
   });
-  
+
   // Navigate to a regular (non-intents) approved payment request
   // Using id=8 which is confirmed to be a regular (non-intents) payment
   await page.goto(
     "https://webassemblymusic-treasury.near.page/?page=payments&tab=history&id=8"
   );
-  
+
   // Wait for the page to load
   await page.waitForTimeout(3000);
-  
+
   // Check that this is an approved proposal and verify transaction links
-  await expect(page.locator('text=Payment Request Funded')).toBeVisible();
-  
+  await expect(page.locator("text=Payment Request Funded")).toBeVisible();
+
   // Check for transaction links section - this should always be present for approved proposals
-  await expect(page.locator('text=Payment Request Funded')).toBeVisible();
-  await expect(page.locator('label:has-text("Transaction Links")')).toBeVisible();
-  
+  await expect(page.locator("text=Payment Request Funded")).toBeVisible();
+  await expect(
+    page.locator('label:has-text("Transaction Links")')
+  ).toBeVisible();
+
   // Check for NEAR Blocks link
   const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');
   await expect(nearBlocksButton).toBeVisible();
-  
+
   // For regular (non-intents) payments, target chain transaction link should NOT be shown
-  const targetTxLink = page.locator('a:has-text("on etherscan.io"), a:has-text("on polygonscan.com"), a:has-text("on bscscan.com")');
+  const targetTxLink = page.locator(
+    'a:has-text("on etherscan.io"), a:has-text("on polygonscan.com"), a:has-text("on bscscan.com")'
+  );
   await expect(targetTxLink).not.toBeVisible();
-  
+
   // Verify that no fallback transaction links are shown
-  await expect(page.locator('a:has-text("Search execution")')).not.toBeVisible();
-  
-  console.log('SUCCESS: Target chain transaction link correctly hidden for regular payment');
+  await expect(
+    page.locator('a:has-text("Search execution")')
+  ).not.toBeVisible();
+
+  console.log(
+    "SUCCESS: Target chain transaction link correctly hidden for regular payment"
+  );
 });

--- a/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
@@ -1,7 +1,13 @@
 import { test } from "../../util/test.js";
 import { expect } from "@playwright/test";
-import { redirectWeb4, getLocalWidgetContent } from "../../util/web4.js";
+import { redirectWeb4 } from "../../util/web4.js";
 
+test.use({
+  viewport: {
+    width: 1280,
+    height: 800,
+  },
+});
 test("NEAR Intents payment request for ETH", async ({ page }) => {
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
@@ -45,10 +51,8 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
   ).toBeVisible();
 
   // Check for fee information (if present)
-  const feeSection = page.locator("text=Network Fee");
-  if (await feeSection.isVisible()) {
-    await expect(feeSection).toBeVisible();
-  }
+  const feeSection = page.getByText("Estimated Fee", { exact: true });
+  await expect(feeSection).toBeVisible({ timeout: 15_000 });
 
   // Check for transaction links section - this should always be present for approved proposals
   await expect(
@@ -65,9 +69,6 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
       'a[href*="nearblocks.io/txns/2trLm2bSSFiUDt2xckM3UW6C6BND4iksiqEihaEjtcbC"]'
     )
   ).toBeVisible();
-
-  // Wait a bit more for the target chain transaction to be fetched
-  await page.waitForTimeout(2000);
 
   // Check for target chain transaction link (Ethereum in this case)
   await expect(
@@ -86,6 +87,8 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
     path: "test-results/intents-payment-detail-final.png",
     fullPage: true,
   });
+
+  await page.waitForTimeout(500);
 });
 
 test("NEAR Intents payment request for NEAR", async ({ page }) => {
@@ -150,6 +153,8 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
   console.log(
     "SUCCESS: Target chain transaction link correctly hidden for NEAR payment"
   );
+
+  await page.waitForTimeout(500);
 });
 
 test("Regular payment request shows transaction links", async ({ page }) => {
@@ -209,4 +214,6 @@ test("Regular payment request shows transaction links", async ({ page }) => {
   console.log(
     "SUCCESS: Target chain transaction link correctly hidden for regular payment"
   );
+
+  await page.waitForTimeout(500);
 });

--- a/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
@@ -8,6 +8,15 @@ test.use({
     height: 800,
   },
 });
+
+test.beforeEach(async ({ page }, testInfo) => {
+  // Skip all tests in this file if not running on the treasury-testing project
+  test.skip(
+    testInfo.project.name !== "treasury-testing",
+    "These tests only run on the treasury-testing project"
+  );
+});
+
 test("NEAR Intents payment request for ETH", async ({ page }) => {
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";

--- a/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
@@ -6,6 +6,7 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
   const modifiedWidgets = {};
+  
   await redirectWeb4({
     page,
     contractId: instanceAccount,
@@ -25,6 +26,30 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
       'div[data-component="widgets.treasury-factory.near/widget/components.TokenAmountAndIcon"]'
     )
   ).toContainText("0.005 ETH");
+  
+  // Wait for network info to load
+  await page.waitForTimeout(3000);
+  
+  // Check that network information is displayed for intents payments
+  await expect(page.locator('text=Network')).toBeVisible();
+  // Look for the network name specifically under the Network label
+  await expect(page.locator('span.text-capitalize').filter({ hasText: 'eth' })).toBeVisible();
+  
+  // Check for fee information (if present)
+  const feeSection = page.locator('text=Network Fee');
+  if (await feeSection.isVisible()) {
+    await expect(feeSection).toBeVisible();
+  }
+  
+  // Check for transaction links section (if present for approved payments)
+  const transactionSection = page.locator('text=Transaction Links');
+  if (await transactionSection.isVisible()) {
+    await expect(transactionSection).toBeVisible();
+    await expect(page.locator('text=View on NEAR Blocks')).toBeVisible();
+  }
+  
+  // Take a screenshot to see the final result
+  await page.screenshot({ path: 'test-results/intents-payment-detail-final.png', fullPage: true });
 });
 
 test("NEAR Intents payment request for NEAR", async ({ page }) => {

--- a/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
@@ -49,7 +49,7 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
   }
   
   // Check for transaction links section - this should always be present for approved proposals
-  await expect(page.locator('text=Transaction Links')).toBeVisible();
+  await expect(page.locator('label:has-text("Transaction Links")')).toBeVisible();
   
   // Check for NEAR Blocks link
   const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');
@@ -111,7 +111,7 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
   
   // Check for transaction links section - this should always be present for approved proposals
   await expect(page.locator('text=Payment Request Funded')).toBeVisible();
-  await expect(page.locator('text=Transaction Links')).toBeVisible();
+  await expect(page.locator('label:has-text("Transaction Links")')).toBeVisible();
   
   // Check for NEAR Blocks link
   const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');
@@ -162,7 +162,7 @@ test("Regular payment request shows transaction links", async ({ page }) => {
   
   // Check for transaction links section - this should always be present for approved proposals
   await expect(page.locator('text=Payment Request Funded')).toBeVisible();
-  await expect(page.locator('text=Transaction Links')).toBeVisible();
+  await expect(page.locator('label:has-text("Transaction Links")')).toBeVisible();
   
   // Check for NEAR Blocks link
   const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');

--- a/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
+++ b/playwright-tests/tests/intents/intents-payment-request-detail.spec.js
@@ -48,10 +48,10 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
     await expect(feeSection).toBeVisible();
   }
   
-  // Check for transaction links section (should be present for all approved proposals)
+  // Check for transaction links section - this should always be present for approved proposals
   await expect(page.locator('text=Transaction Links')).toBeVisible();
   
-  // Check for NEAR Blocks link (either "View execution" or "Search execution")
+  // Check for NEAR Blocks link
   const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');
   await expect(nearBlocksButton).toBeVisible();
   
@@ -63,6 +63,9 @@ test("NEAR Intents payment request for ETH", async ({ page }) => {
   
   // Check for target chain transaction link (Ethereum in this case)
   await expect(page.locator('a[href*="etherscan.io/tx/0x8f52efccdccc3bddc82abc15e259b3d1671959a9694f09d20276892a5863e8d6"]')).toBeVisible();
+  
+  // Verify that no fallback transaction links are shown
+  await expect(page.locator('a:has-text("Search execution")')).not.toBeVisible();
   
   // Take a screenshot to see the final result
   await page.screenshot({ path: 'test-results/intents-payment-detail-final.png', fullPage: true });
@@ -106,7 +109,7 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
   // Check that network information is displayed for intents payments
   await expect(page.locator('text=Network')).toBeVisible();
   
-  // Check for transaction links section (should be present for approved proposals)
+  // Check for transaction links section - this should always be present for approved proposals
   await expect(page.locator('text=Payment Request Funded')).toBeVisible();
   await expect(page.locator('text=Transaction Links')).toBeVisible();
   
@@ -117,6 +120,10 @@ test("NEAR Intents payment request for NEAR", async ({ page }) => {
   // For NEAR-to-NEAR intents payments, target chain transaction link should NOT be shown
   const targetTxLink = page.locator('a:has-text("on etherscan.io"), a:has-text("on polygonscan.com"), a:has-text("on bscscan.com")');
   await expect(targetTxLink).not.toBeVisible();
+  
+  // Verify that no fallback transaction links are shown
+  await expect(page.locator('a:has-text("Search execution")')).not.toBeVisible();
+  
   console.log('SUCCESS: Target chain transaction link correctly hidden for NEAR payment');
 });
 
@@ -153,15 +160,20 @@ test("Regular payment request shows transaction links", async ({ page }) => {
   // Check that this is an approved proposal and verify transaction links
   await expect(page.locator('text=Payment Request Funded')).toBeVisible();
   
-  // Check for transaction links section (should be present for all approved proposals)
+  // Check for transaction links section - this should always be present for approved proposals
+  await expect(page.locator('text=Payment Request Funded')).toBeVisible();
   await expect(page.locator('text=Transaction Links')).toBeVisible();
   
-  // Check for NEAR Blocks link (either "View execution" or "Search execution")
+  // Check for NEAR Blocks link
   const nearBlocksButton = page.locator('a:has-text("on nearblocks.io")');
   await expect(nearBlocksButton).toBeVisible();
   
   // For regular (non-intents) payments, target chain transaction link should NOT be shown
   const targetTxLink = page.locator('a:has-text("on etherscan.io"), a:has-text("on polygonscan.com"), a:has-text("on bscscan.com")');
   await expect(targetTxLink).not.toBeVisible();
+  
+  // Verify that no fallback transaction links are shown
+  await expect(page.locator('a:has-text("Search execution")')).not.toBeVisible();
+  
   console.log('SUCCESS: Target chain transaction link correctly hidden for regular payment');
 });

--- a/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
+++ b/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
@@ -1,0 +1,93 @@
+import { test } from "../../util/test.js";
+import { expect } from "@playwright/test";
+import { redirectWeb4, getLocalWidgetContent } from "../../util/web4.js";
+
+test("USDC on ETH payment showcase", async ({ page }) => {
+  const instanceAccount = "webassemblymusic-treasury.near";
+  const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
+  const modifiedWidgets = {};
+  
+  // Capture browser console logs
+  page.on('console', msg => {
+    if (msg.type() === 'log' || msg.type() === 'error') {
+      console.log(`Browser ${msg.type()}: ${msg.text()}`);
+    }
+  });
+  
+  await redirectWeb4({
+    page,
+    contractId: instanceAccount,
+    treasury: daoAccount,
+    networkId: "mainnet",
+    modifiedWidgets,
+    callWidgetNodeURLForContractWidgets: false,
+  });
+  
+  // Navigate to proposal 6 - USDC on ETH payment
+  await page.goto(
+    "https://webassemblymusic-treasury.near.page/?page=payments&tab=history&id=6"
+  );
+  
+  // Wait for page to load and show the proposal details
+  await page.waitForTimeout(2000);
+  
+  // Verify this is a USDC payment by looking for the token amount
+  await expect(page.locator('text=12 USDC')).toBeVisible();
+  
+  // Wait for network info and transaction links to load
+  await page.waitForTimeout(3000);
+  
+  // Check that network information is displayed (should show ETH)
+  await expect(page.locator('text=Network')).toBeVisible();
+  await expect(page.locator('span.text-capitalize').filter({ hasText: 'eth' })).toBeVisible();
+  
+  // Check that this is an approved proposal with transaction links
+  await expect(page.locator('text=Payment Request Funded')).toBeVisible();
+  await expect(page.locator('text=Transaction Links')).toBeVisible();
+  
+  // Find and click on the NEAR transaction link
+  const nearTxLink = page.locator('a:has-text("on nearblocks.io")');
+  await expect(nearTxLink).toBeVisible();
+  
+  // Get the href URL and navigate to it in the same tab
+  const nearTxUrl = await nearTxLink.getAttribute('href');
+  console.log('Navigating to NEAR transaction:', nearTxUrl);
+  await page.goto(nearTxUrl);
+  
+  // Wait for the NEAR blocks page to load
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(3000);
+  
+  // Navigate back to the treasury page
+  await page.goBack();
+  await page.waitForLoadState('networkidle');
+  
+  // Wait a moment before checking for target chain link
+  await page.waitForTimeout(2000);
+  
+  // Find and navigate to the Ethereum transaction link (if available)
+  const ethTxLink = page.locator('a:has-text("on etherscan.io")');
+  if (await ethTxLink.isVisible()) {
+    console.log('Found Ethereum transaction link');
+    
+    // Get the href URL and navigate to it in the same tab
+    const ethTxUrl = await ethTxLink.getAttribute('href');
+    console.log('Navigating to Ethereum transaction:', ethTxUrl);
+    await page.goto(ethTxUrl);
+    
+    // Wait for the Etherscan page to load
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(3000);
+    
+    // Navigate back to the treasury page
+    await page.goBack();
+    await page.waitForLoadState('networkidle');
+  } else {
+    console.log('Ethereum transaction link not yet available - may still be loading from POA Bridge API');
+  }
+  
+  // Final pause to show the complete page
+  await page.waitForTimeout(2000);
+  
+  console.log('SHOWCASE COMPLETE: USDC on ETH payment with transaction links demonstrated');
+});

--- a/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
+++ b/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
@@ -16,6 +16,7 @@ test("USDC on ETH payment showcase @treasury-testing", async ({
     testInfo.project.name !== "treasury-testing",
     "This test only runs on the treasury-testing project"
   );
+  test.setTimeout(60_000);
 
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
@@ -74,6 +75,13 @@ test("USDC on ETH payment showcase @treasury-testing", async ({
     page.locator('label:has-text("Transaction Links")')
   ).toBeVisible();
 
+  const networkSection = page.getByText("Network Ethereum");
+  await expect(
+    networkSection.locator(
+      'img[src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICAgIDxnIGNsaXAtcGF0aD0idXJsKCNldGhlcmV1bV9fYSkiPgogICAgICAgIDxwYXRoIGZpbGw9IiMwMDAiIGQ9Ik0yNCAwSDB2MjRoMjR6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iIzhGRkNGMyIgZD0iTTEyIDR2NS45MTJsNSAyLjIzN3oiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjQ0FCQ0Y4IiBkPSJtMTIgNC01IDguMTQ4IDUtMi4yMzV6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iI0NCQTdGNSIgZD0iTTEyIDE1Ljk4VjIwbDUtNi45MnoiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjNzRBMEYzIiBkPSJNMTIgMjB2LTQuMDJsLTUtMi45eiIvPgogICAgICAgIDxwYXRoIGZpbGw9IiNDQkE3RjUiIGQ9Im0xMiAxNS4wNDkgNS0yLjktNS0yLjIzNnoiLz4KICAgICAgICA8cGF0aCBmaWxsPSIjNzRBMEYzIiBkPSJtNyAxMi4xNDkgNSAyLjlWOS45MTN6Ii8+CiAgICAgICAgPHBhdGggZmlsbD0iIzIwMjY5OSIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJtMTIgMTUuMDQ4LTUtMi45TDEyIDRsNSA4LjE0OHptLTQuNjctMy4xMzYgNC41ODgtNy40NzV2NS40MzV6bS0uMDY4LjIwNCA0LjY1Ni0yLjA2OHY0Ljc2OHptNC44MTYtMi4wNjh2NC43NjhsNC42NTMtMi43em0wLS4xNzYgNC41ODggMi4wNC00LjU4OC03LjQ3NXoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgICAgIDxwYXRoIGZpbGw9IiMyMDI2OTkiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0ibTEyIDE1LjkxNy01LTIuODRMMTIgMjBsNS02LjkyNHptLTQuNDQtMi4zNDEgNC4zNiAyLjQ4djMuNTZ6bTQuNTE5IDIuNDh2My41Nmw0LjM2LTYuMDR6IiBjbGlwLXJ1bGU9ImV2ZW5vZGQiLz4KICAgIDwvZz4KICAgIDxkZWZzPgogICAgICAgIDxjbGlwUGF0aCBpZD0iZXRoZXJldW1fX2EiPgogICAgICAgICAgICA8cGF0aCBmaWxsPSIjZmZmIiBkPSJNMCAwaDI0djI0SDB6Ii8+CiAgICAgICAgPC9jbGlwUGF0aD4KICAgIDwvZGVmcz4KPC9zdmc+Cg=="]'
+    )
+  ).toBeVisible();
+
   // Find and click on the NEAR transaction link
   const nearTxLink = page.locator('a:has-text("on nearblocks.io")');
   await expect(nearTxLink).toBeVisible();
@@ -96,26 +104,20 @@ test("USDC on ETH payment showcase @treasury-testing", async ({
 
   // Find and navigate to the Ethereum transaction link (if available)
   const ethTxLink = page.locator('a:has-text("on etherscan.io")');
-  if (await ethTxLink.isVisible()) {
-    console.log("Found Ethereum transaction link");
+  console.log("Found Ethereum transaction link");
 
-    // Get the href URL and navigate to it in the same tab
-    const ethTxUrl = await ethTxLink.getAttribute("href");
-    console.log("Navigating to Ethereum transaction:", ethTxUrl);
-    await page.goto(ethTxUrl);
+  // Get the href URL and navigate to it in the same tab
+  const ethTxUrl = await ethTxLink.getAttribute("href");
+  console.log("Navigating to Ethereum transaction:", ethTxUrl);
+  await page.goto(ethTxUrl);
 
-    // Wait for the Etherscan page to load
-    await page.waitForLoadState("networkidle");
-    await page.waitForTimeout(3000);
+  // Wait for the Etherscan page to load
+  await page.waitForLoadState("networkidle");
+  await page.waitForTimeout(3000);
 
-    // Navigate back to the treasury page
-    await page.goBack();
-    await page.waitForLoadState("networkidle");
-  } else {
-    console.log(
-      "Ethereum transaction link not yet available - may still be loading from POA Bridge API"
-    );
-  }
+  // Navigate back to the treasury page
+  await page.goBack();
+  await page.waitForLoadState("networkidle");
 
   // Final pause to show the complete page
   await page.waitForTimeout(2000);

--- a/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
+++ b/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
@@ -2,6 +2,10 @@ import { test } from "../../util/test.js";
 import { expect } from "@playwright/test";
 import { redirectWeb4, getLocalWidgetContent } from "../../util/web4.js";
 
+test.use({viewport: {
+    width: 1280,
+    height: 800
+}})
 test("USDC on ETH payment showcase", async ({ page }) => {
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
@@ -38,12 +42,17 @@ test("USDC on ETH payment showcase", async ({ page }) => {
   await page.waitForTimeout(3000);
   
   // Check that network information is displayed (should show ETH)
-  await expect(page.locator('text=Network')).toBeVisible();
+  await expect(page.locator('label:has-text("Network"):not(:has-text("Fee"))')).toBeVisible();
   await expect(page.locator('span.text-capitalize').filter({ hasText: 'eth' })).toBeVisible();
+  
+  // Check that estimated fee is displayed
+  await expect(page.locator('label:has-text("Estimated Fee")')).toBeVisible();
+  await expect(page.locator('text=0.3 USDC')).toBeVisible();
+  await expect(page.locator('text=This is an estimated fee. Check the transaction links below for the actual fee charged.')).toBeVisible();
   
   // Check that this is an approved proposal with transaction links
   await expect(page.locator('text=Payment Request Funded')).toBeVisible();
-  await expect(page.locator('text=Transaction Links')).toBeVisible();
+  await expect(page.locator('label:has-text("Transaction Links")')).toBeVisible();
   
   // Find and click on the NEAR transaction link
   const nearTxLink = page.locator('a:has-text("on nearblocks.io")');

--- a/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
+++ b/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
@@ -2,22 +2,24 @@ import { test } from "../../util/test.js";
 import { expect } from "@playwright/test";
 import { redirectWeb4, getLocalWidgetContent } from "../../util/web4.js";
 
-test.use({viewport: {
+test.use({
+  viewport: {
     width: 1280,
-    height: 800
-}})
+    height: 800,
+  },
+});
 test("USDC on ETH payment showcase", async ({ page }) => {
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
   const modifiedWidgets = {};
-  
+
   // Capture browser console logs
-  page.on('console', msg => {
-    if (msg.type() === 'log' || msg.type() === 'error') {
+  page.on("console", (msg) => {
+    if (msg.type() === "log" || msg.type() === "error") {
       console.log(`Browser ${msg.type()}: ${msg.text()}`);
     }
   });
-  
+
   await redirectWeb4({
     page,
     contractId: instanceAccount,
@@ -26,77 +28,91 @@ test("USDC on ETH payment showcase", async ({ page }) => {
     modifiedWidgets,
     callWidgetNodeURLForContractWidgets: false,
   });
-  
+
   // Navigate to proposal 6 - USDC on ETH payment
   await page.goto(
     "https://webassemblymusic-treasury.near.page/?page=payments&tab=history&id=6"
   );
-  
+
   // Wait for page to load and show the proposal details
   await page.waitForTimeout(2000);
-  
+
   // Verify this is a USDC payment by looking for the token amount
-  await expect(page.locator('text=12 USDC')).toBeVisible();
-  
+  await expect(page.locator("text=12 USDC")).toBeVisible();
+
   // Wait for network info and transaction links to load
   await page.waitForTimeout(3000);
-  
+
   // Check that network information is displayed (should show ETH)
-  await expect(page.locator('label:has-text("Network"):not(:has-text("Fee"))')).toBeVisible();
-  await expect(page.locator('span.text-capitalize').filter({ hasText: 'eth' })).toBeVisible();
-  
+  await expect(
+    page.locator('label:has-text("Network"):not(:has-text("Fee"))')
+  ).toBeVisible();
+  await expect(
+    page.locator("span.text-capitalize").filter({ hasText: "eth" })
+  ).toBeVisible();
+
   // Check that estimated fee is displayed
   await expect(page.locator('label:has-text("Estimated Fee")')).toBeVisible();
-  await expect(page.locator('text=0.3 USDC')).toBeVisible();
-  await expect(page.locator('text=This is an estimated fee. Check the transaction links below for the actual fee charged.')).toBeVisible();
-  
+  await expect(page.locator("text=0.3 USDC")).toBeVisible();
+  await expect(
+    page.locator(
+      "text=This is an estimated fee. Check the transaction links below for the actual fee charged."
+    )
+  ).toBeVisible();
+
   // Check that this is an approved proposal with transaction links
-  await expect(page.locator('text=Payment Request Funded')).toBeVisible();
-  await expect(page.locator('label:has-text("Transaction Links")')).toBeVisible();
-  
+  await expect(page.locator("text=Payment Request Funded")).toBeVisible();
+  await expect(
+    page.locator('label:has-text("Transaction Links")')
+  ).toBeVisible();
+
   // Find and click on the NEAR transaction link
   const nearTxLink = page.locator('a:has-text("on nearblocks.io")');
   await expect(nearTxLink).toBeVisible();
-  
+
   // Get the href URL and navigate to it in the same tab
-  const nearTxUrl = await nearTxLink.getAttribute('href');
-  console.log('Navigating to NEAR transaction:', nearTxUrl);
+  const nearTxUrl = await nearTxLink.getAttribute("href");
+  console.log("Navigating to NEAR transaction:", nearTxUrl);
   await page.goto(nearTxUrl);
-  
+
   // Wait for the NEAR blocks page to load
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState("networkidle");
   await page.waitForTimeout(3000);
-  
+
   // Navigate back to the treasury page
   await page.goBack();
-  await page.waitForLoadState('networkidle');
-  
+  await page.waitForLoadState("networkidle");
+
   // Wait a moment before checking for target chain link
   await page.waitForTimeout(2000);
-  
+
   // Find and navigate to the Ethereum transaction link (if available)
   const ethTxLink = page.locator('a:has-text("on etherscan.io")');
   if (await ethTxLink.isVisible()) {
-    console.log('Found Ethereum transaction link');
-    
+    console.log("Found Ethereum transaction link");
+
     // Get the href URL and navigate to it in the same tab
-    const ethTxUrl = await ethTxLink.getAttribute('href');
-    console.log('Navigating to Ethereum transaction:', ethTxUrl);
+    const ethTxUrl = await ethTxLink.getAttribute("href");
+    console.log("Navigating to Ethereum transaction:", ethTxUrl);
     await page.goto(ethTxUrl);
-    
+
     // Wait for the Etherscan page to load
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState("networkidle");
     await page.waitForTimeout(3000);
-    
+
     // Navigate back to the treasury page
     await page.goBack();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState("networkidle");
   } else {
-    console.log('Ethereum transaction link not yet available - may still be loading from POA Bridge API');
+    console.log(
+      "Ethereum transaction link not yet available - may still be loading from POA Bridge API"
+    );
   }
-  
+
   // Final pause to show the complete page
   await page.waitForTimeout(2000);
-  
-  console.log('SHOWCASE COMPLETE: USDC on ETH payment with transaction links demonstrated');
+
+  console.log(
+    "SHOWCASE COMPLETE: USDC on ETH payment with transaction links demonstrated"
+  );
 });

--- a/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
+++ b/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
@@ -8,9 +8,7 @@ test.use({
     height: 800,
   },
 });
-test("USDC on ETH payment showcase @treasury-testing", async ({
-  page,
-}, testInfo) => {
+test("USDC on ETH payment request detail", async ({ page }, testInfo) => {
   // Skip this test if not running on the treasury-testing project
   test.skip(
     testInfo.project.name !== "treasury-testing",
@@ -84,11 +82,16 @@ test("USDC on ETH payment showcase @treasury-testing", async ({
 
   // Find and click on the NEAR transaction link
   const nearTxLink = page.locator('a:has-text("on nearblocks.io")');
-  await expect(nearTxLink).toBeVisible();
 
+  await expect(nearTxLink).toBeVisible();
+  await nearTxLink.hover();
+  await page.waitForTimeout(500);
   // Get the href URL and navigate to it in the same tab
   const nearTxUrl = await nearTxLink.getAttribute("href");
   console.log("Navigating to NEAR transaction:", nearTxUrl);
+  expect(nearTxUrl).toBe(
+    "https://nearblocks.io/txns/BQcD4XxrXwBVryBkuyXevsuk9eFQhZ23gXusQPaxTJ32"
+  );
   await page.goto(nearTxUrl);
 
   // Wait for the NEAR blocks page to load
@@ -97,18 +100,24 @@ test("USDC on ETH payment showcase @treasury-testing", async ({
 
   // Navigate back to the treasury page
   await page.goBack();
-  await page.waitForLoadState("networkidle");
+  await expect(page.locator("text=12 USDC")).toBeVisible();
 
   // Wait a moment before checking for target chain link
-  await page.waitForTimeout(2000);
+  await page.waitForTimeout(200);
 
   // Find and navigate to the Ethereum transaction link (if available)
   const ethTxLink = page.locator('a:has-text("on etherscan.io")');
+  await ethTxLink.hover();
+  await page.waitForTimeout(500);
   console.log("Found Ethereum transaction link");
 
   // Get the href URL and navigate to it in the same tab
   const ethTxUrl = await ethTxLink.getAttribute("href");
   console.log("Navigating to Ethereum transaction:", ethTxUrl);
+  expect(ethTxUrl).toBe(
+    "https://etherscan.io/tx/0xe1169baab6d9c0b459c2129c2660486a742a4986175fc86e2417054c0f8b5ad0"
+  );
+
   await page.goto(ethTxUrl);
 
   // Wait for the Etherscan page to load
@@ -117,10 +126,7 @@ test("USDC on ETH payment showcase @treasury-testing", async ({
 
   // Navigate back to the treasury page
   await page.goBack();
-  await page.waitForLoadState("networkidle");
-
-  // Final pause to show the complete page
-  await page.waitForTimeout(2000);
+  await expect(page.locator("text=12 USDC")).toBeVisible();
 
   console.log(
     "SHOWCASE COMPLETE: USDC on ETH payment with transaction links demonstrated"

--- a/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
+++ b/playwright-tests/tests/intents/usdc-eth-payment-showcase.spec.js
@@ -8,7 +8,15 @@ test.use({
     height: 800,
   },
 });
-test("USDC on ETH payment showcase", async ({ page }) => {
+test("USDC on ETH payment showcase @treasury-testing", async ({
+  page,
+}, testInfo) => {
+  // Skip this test if not running on the treasury-testing project
+  test.skip(
+    testInfo.project.name !== "treasury-testing",
+    "This test only runs on the treasury-testing project"
+  );
+
   const instanceAccount = "webassemblymusic-treasury.near";
   const daoAccount = "webassemblymusic-treasury.sputnik-dao.near";
   const modifiedWidgets = {};

--- a/playwright-tests/util/web4.js
+++ b/playwright-tests/util/web4.js
@@ -45,6 +45,7 @@ export function getLocalWidgetContent(key, context = {}) {
     .replaceAll("${REPL_BOOTSTRAP_ACCOUNT}", "bootstrap.treasury-factory.near")
     .replaceAll("${REPL_TREASURY}", treasury)
     .replaceAll("${REPL_INSTANCE}", account)
+    .replaceAll("${REPL_NEARBLOCKS_KEY}", replacements["REPL_NEARBLOCKS_KEY"])
     .replaceAll(
       "${REPL_BASE_DEPLOYMENT_ACCOUNT}",
       "widgets.treasury-factory.near"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -35,7 +35,7 @@ export default defineConfig({
     headless: true,
     video: {
       mode: process.env.CI ? "on-first-retry" : "on",
-      size: { width: 1024, height: 768 }
+      size: { width: 1280, height: 800 }
     },
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -35,7 +35,7 @@ export default defineConfig({
     headless: true,
     video: {
       mode: process.env.CI ? "on-first-retry" : "on",
-      size: { width: 1280, height: 800 }
+      size: { width: 1280, height: 800 },
     },
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -33,7 +33,10 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     headless: true,
-    video: process.env.CI ? "on-first-retry" : "on",
+    video: {
+      mode: process.env.CI ? "on-first-retry" : "on",
+      size: { width: 1024, height: 768 }
+    },
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
## Summary

Enhances payment request details page for NEAR Intents payments with network information, fee estimation, and cross-chain transaction traceability.

This PR has already got quite a bit of attention: https://x.com/salomonsen_p/status/1941827141038969229

## Videos

USDC on ETH payment request with cross-chain transaction links:



https://github.com/user-attachments/assets/ed27dd29-ad1c-4a5c-bf23-b459d877aa35



Additional payment request examples:




https://github.com/user-attachments/assets/7306b737-6ce2-4ee1-a239-6256fd98eb4d




## What's New

✅ **Target Network Display** - Shows blockchain network (ETH, Polygon, etc.) for intents payments using Chain Defuser API

✅ **Fee Estimation** - Displays estimated withdrawal fees with disclaimer to check actual transaction fees

✅ **Cross-Chain Transaction Links** - Links to both NEAR execution transaction and target chain transfer (when available)

✅ **Enhanced Testing** - Added comprehensive tests for ETH/NEAR intents payments and regular payments

## Files Changed
- `ProposalDetailsPage.jsx` - Added network fetching, fee estimation, and transaction link logic
- `intents-payment-request-detail.spec.js` - Enhanced test coverage for new features  
- `usdc-eth-payment-showcase.spec.js` - New showcase test for USDC payments
- `playwright.config.js` - Updated video recording settings

Closes #587