### PR TITLE
feat: Disable voting on proposals with expired 1Click API quotes

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/components/VoteActions.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/VoteActions.jsx
@@ -33,6 +33,8 @@ const isProposalDetailsPage = props.isProposalDetailsPage;
 const hasOneDeleteIcon = props.hasOneDeleteIcon;
 const isIntentsRequest = props.isIntentsRequest;
 const proposal = props.proposal;
+const isQuoteExpired = props.isQuoteExpired;
+const quoteDeadline = props.quoteDeadline;
 
 const alreadyVoted = Object.keys(votes).includes(accountId);
 const userVote = votes[accountId];
@@ -328,7 +330,40 @@ return (
       </div>
     ) : (
       <div className={containerClass}>
-        {!isReadyToBeWithdrawn ? (
+        {isQuoteExpired ? (
+          <div className="d-flex align-items-center gap-2 w-100">
+            <div className="d-flex align-items-center gap-2 text-muted flex-grow-1">
+              <i className="bi bi-info-circle"></i>
+              <span>
+                Voting is no longer available. The 1Click API quote for this request expired on {quoteDeadline.toLocaleString()}.
+                <Widget
+                  loading=""
+                  src="${REPL_BASE_DEPLOYMENT_ACCOUNT}/widget/components.OverlayTrigger"
+                  props={{
+                    popup: (
+                      <div>
+                        The exchange rate quoted by 1Click API has expired. Voting is disabled to prevent
+                        potential loss of funds from executing the swap at an outdated rate.
+                      </div>
+                    ),
+                    children: (
+                      <span className="text-decoration-underline ms-1" style={{ cursor: "pointer" }}>
+                        Learn more
+                      </span>
+                    ),
+                    instance,
+                  }}
+                />
+              </span>
+            </div>
+            <button className="btn btn-success" disabled style={{ opacity: 0.5 }}>
+              Approve
+            </button>
+            <button className="btn btn-danger" disabled style={{ opacity: 0.5 }}>
+              Reject
+            </button>
+          </div>
+        ) : !isReadyToBeWithdrawn ? (
           <div className="text-center fw-semi-bold">
             Voting is not available before unstaking release{" "}
             <Widget

--- a/playwright-tests/tests/intents/oneclick-exchange-details.spec.js
+++ b/playwright-tests/tests/intents/oneclick-exchange-details.spec.js
@@ -1,0 +1,332 @@
+import { expect } from "@playwright/test";
+import { test } from "../../util/test.js";
+import { redirectWeb4 } from "../../util/web4.js";
+import { mockRpcRequest, updateDaoPolicyMembers } from "../../util/rpcmock.js";
+import { CurrentTimestampInNanoseconds } from "../../util/inventory.js";
+import { setPageAuthSettings } from "../../util/sandboxrpc.js";
+import { KeyPairEd25519 } from "near-api-js/lib/utils/key_pair.js";
+import { mockTheme } from "../../util/theme.js";
+import path from "path";
+import { promises as fs } from "fs";
+
+// Create screenshots directory if it doesn't exist
+const screenshotsDir = path.join(
+  process.cwd(),
+  "screenshots",
+  "oneclick-exchange-details"
+);
+
+test.describe("OneClick Exchange Proposal Details", () => {
+  test.use({ 
+    viewport: { width: 1280, height: 800 },
+    storageState: "playwright-tests/storage-states/wallet-connected-admin.json"
+  });
+
+  test.beforeEach(async ({ page }) => {
+    // Create screenshots directory
+    await fs.mkdir(screenshotsDir, { recursive: true });
+  });
+
+  test("disables voting when 1Click API quote is expired", async ({ 
+    page, 
+    instanceAccount, 
+    daoAccount 
+  }) => {
+    test.setTimeout(60000);
+
+    // Create expired date (1 day ago)
+    const expiredDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    
+    // Create proposal with expired quote deadline in the notes
+    const proposalWithExpiredQuote = {
+      id: 28,
+      proposer: "user.near",
+      votes: { "frol.near": "VoteApprove" },
+      submission_time: CurrentTimestampInNanoseconds,
+      status: "InProgress",
+      description: JSON.stringify({
+        proposal_action: "asset-exchange",
+        notes: `1Click Cross-Network Swap
+
+Swap Details:
+- Amount In: 0.1 ETH
+- Amount Out: 350.00 USDC
+- Destination Network: ethereum
+- Time Estimate: 10 minutes
+- Quote Deadline: ${expiredDate.toLocaleString()}
+
+Deposit Address: test-deposit-address
+
+1Click Service Signature: ed25519:test-signature
+
+This proposal authorizes transferring tokens to 1Click's deposit address.
+1Click will execute the cross-network swap and deliver the swapped tokens back to the treasury's NEAR Intents account.`,
+        tokenIn: "eth.omft.near",
+        tokenOut: "usdc.omft.near",
+        amountIn: "0.1",
+        amountOut: "350.00",
+        slippage: "2"
+      }),
+      kind: {
+        FunctionCall: {
+          receiver_id: "intents.near",
+          actions: [{
+            method_name: "mt_transfer",
+            args: btoa(JSON.stringify({
+              receiver_id: "test-deposit-address",
+              amount: "100000000000000000",
+              token_id: "nep141:eth.omft.near"
+            })),
+            deposit: "1",
+            gas: "100000000000000"
+          }]
+        }
+      }
+    };
+
+    // Set up redirectWeb4 to load widgets from local filesystem
+    await redirectWeb4({
+      page,
+      contractId: instanceAccount,
+      treasury: daoAccount,
+    });
+
+    // Update DAO policy members
+    await updateDaoPolicyMembers({
+      instanceAccount,
+      page,
+      hasAllRole: true,
+    });
+
+    // Mock the get_proposal RPC call
+    await mockRpcRequest({
+      page,
+      filterParams: { method_name: "get_proposal" },
+      modifyOriginalResultFunction: () => proposalWithExpiredQuote,
+    });
+
+    // Mock theme AFTER redirectWeb4
+    await mockTheme(page, "dark");
+
+    // Navigate directly to the proposal details page
+    await page.goto(`https://${instanceAccount}.page?page=asset-exchange&id=28`);
+    
+    // Set up auth settings AFTER navigating to the page (so localStorage is available)
+    await setPageAuthSettings(page, "theori.near", KeyPairEd25519.fromRandom());
+    
+    // Wait for the page to load
+    await page.waitForTimeout(5000);
+    
+    // Check for proposal ID
+    const proposalIdVisible = await page.locator("text=#28").isVisible().catch(() => false);
+    console.log(`Proposal #28 visible: ${proposalIdVisible}`);
+
+    // Check that the expired quote message is displayed
+    const expiredMessage = page.locator("text=/Voting is no longer available.*1Click API quote.*expired/");
+    const messageVisible = await expiredMessage.isVisible().catch(() => false);
+    
+    if (messageVisible) {
+      console.log("✓ Expired quote message is displayed");
+      
+      // Check for the Learn more link
+      const learnMore = await page.locator("text=Learn more").isVisible().catch(() => false);
+      if (learnMore) {
+        console.log("✓ Learn more link is visible");
+      }
+
+      // Verify that vote buttons are disabled
+      const approveButton = page.getByRole('button', { name: 'Approve' });
+      const rejectButton = page.getByRole('button', { name: 'Reject' });
+      
+      const approveDisabled = await approveButton.isDisabled().catch(() => false);
+      const rejectDisabled = await rejectButton.isDisabled().catch(() => false);
+      
+      if (approveDisabled && rejectDisabled) {
+        console.log("✓ Vote buttons are disabled");
+      } else {
+        console.log("✗ Vote buttons are not disabled as expected");
+      }
+      
+      // Check opacity if buttons exist
+      if (await approveButton.count() > 0) {
+        const approveOpacity = await approveButton.evaluate(el => 
+          window.getComputedStyle(el).opacity
+        );
+        const rejectOpacity = await rejectButton.evaluate(el => 
+          window.getComputedStyle(el).opacity
+        );
+        
+        if (parseFloat(approveOpacity) < 1 && parseFloat(rejectOpacity) < 1) {
+          console.log("✓ Buttons have reduced opacity");
+        }
+      }
+
+      // Check that the quote deadline info is shown in the proposal content
+      const deadlineLabel = await page.locator("text=1Click Quote Deadline").isVisible().catch(() => false);
+      const expiredText = await page.locator("text=(EXPIRED)").isVisible().catch(() => false);
+      
+      if (deadlineLabel && expiredText) {
+        console.log("✓ Quote deadline is shown as expired in proposal content");
+      }
+
+      // All checks passed
+      expect(messageVisible).toBeTruthy();
+      expect(approveDisabled).toBeTruthy();
+      expect(rejectDisabled).toBeTruthy();
+    } else {
+      // If the new implementation isn't working, log what we see
+      console.log("Expected expired quote message not found. Checking page state...");
+      
+      // Check if buttons are present at all
+      const approveExists = await page.locator('button:text("Approve")').count();
+      const rejectExists = await page.locator('button:text("Reject")').count();
+      console.log(`Approve button count: ${approveExists}`);
+      console.log(`Reject button count: ${rejectExists}`);
+      
+      // Check if the proposal content is visible
+      const proposalVisible = await page.locator("text=0.1 ETH").isVisible().catch(() => false);
+      console.log(`Proposal content visible: ${proposalVisible}`);
+      
+      // Take a debug screenshot
+      await page.screenshot({
+        path: path.join(screenshotsDir, "expired-quote-debug.png"),
+        fullPage: true,
+      });
+      
+      throw new Error("Expired quote functionality not working as expected. Check debug screenshot.");
+    }
+
+    // Take a screenshot showing the final state
+    await page.screenshot({
+      path: path.join(screenshotsDir, "expired-quote-voting-disabled.png"),
+      fullPage: true,
+    });
+
+    console.log("\nExpired quote test completed successfully!");
+  });
+
+  test("allows voting when 1Click API quote is NOT expired", async ({ 
+    page, 
+    instanceAccount, 
+    daoAccount 
+  }) => {
+    test.setTimeout(60000);
+
+    // Create future date (7 days from now)
+    const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    
+    // Create proposal with valid quote deadline in the notes
+    const proposalWithValidQuote = {
+      id: 29,
+      proposer: "user.near",
+      votes: {},
+      submission_time: CurrentTimestampInNanoseconds,
+      status: "InProgress",
+      description: JSON.stringify({
+        proposal_action: "asset-exchange",
+        notes: `1Click Cross-Network Swap
+
+Swap Details:
+- Amount In: 0.1 ETH
+- Amount Out: 350.00 USDC
+- Destination Network: ethereum
+- Time Estimate: 10 minutes
+- Quote Deadline: ${futureDate.toLocaleString()}
+
+Deposit Address: test-deposit-address
+
+1Click Service Signature: ed25519:test-signature
+
+This proposal authorizes transferring tokens to 1Click's deposit address.
+1Click will execute the cross-network swap and deliver the swapped tokens back to the treasury's NEAR Intents account.`,
+        tokenIn: "eth.omft.near",
+        tokenOut: "usdc.omft.near",
+        amountIn: "0.1",
+        amountOut: "350.00",
+        slippage: "2"
+      }),
+      kind: {
+        FunctionCall: {
+          receiver_id: "intents.near",
+          actions: [{
+            method_name: "mt_transfer",
+            args: btoa(JSON.stringify({
+              receiver_id: "test-deposit-address",
+              amount: "100000000000000000",
+              token_id: "nep141:eth.omft.near"
+            })),
+            deposit: "1",
+            gas: "100000000000000"
+          }]
+        }
+      }
+    };
+
+    // Set up redirectWeb4 to load widgets from local filesystem
+    await redirectWeb4({
+      page,
+      contractId: instanceAccount,
+      treasury: daoAccount,
+    });
+
+    // Update DAO policy members
+    await updateDaoPolicyMembers({
+      instanceAccount,
+      page,
+      hasAllRole: true,
+    });
+
+    // Mock the get_proposal RPC call
+    await mockRpcRequest({
+      page,
+      filterParams: { method_name: "get_proposal" },
+      modifyOriginalResultFunction: () => proposalWithValidQuote,
+    });
+
+    // Mock theme AFTER redirectWeb4
+    await mockTheme(page, "light");
+
+    // Navigate directly to the proposal details page
+    await page.goto(`https://${instanceAccount}.page?page=asset-exchange&id=29`);
+    
+    // Set up auth settings AFTER navigating to the page (so localStorage is available)
+    await setPageAuthSettings(page, "theori.near", KeyPairEd25519.fromRandom());
+    
+    // Wait for the page to load
+    await page.waitForTimeout(5000);
+    
+    // Check that the expired quote message is NOT displayed
+    const expiredMessage = page.locator("text=/Voting is no longer available.*1Click API quote.*expired/");
+    const messageVisible = await expiredMessage.isVisible().catch(() => false);
+    
+    expect(messageVisible).toBeFalsy();
+    console.log("✓ No expired quote message (as expected for valid quote)");
+
+    // Verify that vote buttons are ENABLED
+    const approveButton = page.getByRole('button', { name: 'Approve' });
+    const rejectButton = page.getByRole('button', { name: 'Reject' });
+    
+    const approveEnabled = await approveButton.isEnabled().catch(() => false);
+    const rejectEnabled = await rejectButton.isEnabled().catch(() => false);
+    
+    expect(approveEnabled).toBeTruthy();
+    expect(rejectEnabled).toBeTruthy();
+    console.log("✓ Vote buttons are enabled");
+    
+    // Check that the quote deadline info is shown but NOT expired
+    const deadlineLabel = await page.locator("text=1Click Quote Deadline").isVisible().catch(() => false);
+    const expiredText = await page.locator("text=(EXPIRED)").isVisible().catch(() => false);
+    
+    expect(deadlineLabel).toBeTruthy();
+    expect(expiredText).toBeFalsy();
+    console.log("✓ Quote deadline is shown as valid");
+
+    // Take a screenshot showing the valid state
+    await page.screenshot({
+      path: path.join(screenshotsDir, "valid-quote-voting-enabled.png"),
+      fullPage: true,
+    });
+
+    console.log("\nValid quote test completed successfully!");
+  });
+});

--- a/playwright-tests/util/rpcmock.js
+++ b/playwright-tests/util/rpcmock.js
@@ -1,4 +1,11 @@
 export const MOCK_RPC_URL = "http://127.0.0.1:14500";
+// Add support for fastnear RPC endpoints used by web4
+const RPC_URL_PATTERNS = [
+  MOCK_RPC_URL,
+  "**/rpc.mainnet.fastnear.com/**",
+  "**/free.rpc.fastnear.com/**",
+  "**/rpc.mainnet.near.org/**"
+];
 
 export async function mockRpcRequest({
   page,
@@ -6,7 +13,8 @@ export async function mockRpcRequest({
   mockedResult = {},
   modifyOriginalResultFunction = null,
 }) {
-  await page.route(MOCK_RPC_URL, async (route, request) => {
+  // Create a route handler that works for all RPC endpoints
+  const routeHandler = async (route, request) => {
     const postData = request.postDataJSON();
 
     const filterParamsKeys = Object.keys(filterParams);
@@ -64,7 +72,12 @@ export async function mockRpcRequest({
     } else {
       route.fallback();
     }
-  });
+  };
+  
+  // Apply the route handler to all RPC URL patterns
+  for (const pattern of RPC_URL_PATTERNS) {
+    await page.route(pattern, routeHandler);
+  }
 }
 
 export function getOldPolicy(


### PR DESCRIPTION
## Summary

This PR implements a security feature that prevents voting on asset exchange proposals when the 1Click API quote has expired. This protects the treasury from potential losses due to executing swaps at outdated exchange rates.

Fixes #635

## Changes

### 🔧 Implementation

1. **ProposalDetailsPage.jsx** (`pages/asset-exchange/ProposalDetailsPage.jsx`)
   - Extracts quote deadline from proposal notes for 1Click exchange proposals
   - Passes `isQuoteExpired` and `quoteDeadline` props to VoteActions component
   - Displays quote deadline in proposal content with "(EXPIRED)" label when applicable

2. **VoteActions.jsx** (`components/VoteActions.jsx`)
   - Checks if quote is expired before enabling vote buttons
   - Shows informative message: "Voting is no longer available. The 1Click API quote for this request expired on [date]"
   - Includes "Learn more" tooltip explaining the security measure
   - Displays disabled Approve/Reject buttons with reduced opacity

3. **RPC Mocking Enhancement** (`playwright-tests/util/rpcmock.js`)
   - Updated `mockRpcRequest` to handle fastnear.com RPC endpoints in addition to localhost
   - Enables proper testing with web4 approach

### ✅ Testing

Added comprehensive test coverage in `oneclick-exchange-details.spec.js`:
- ✅ Disables voting when quote is expired
- ✅ Allows voting when quote is valid
- ✅ Shows appropriate messages and visual indicators

## Screenshots

When quote is expired:
- Voting buttons are disabled
- Clear message explains why voting is unavailable
- Quote deadline shown with "(EXPIRED)" label

## Security Impact

This feature prevents:
- Approval of proposals with outdated exchange rates
- Potential loss of funds from executing swaps at unfavorable rates
- Failed transactions due to expired quotes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>