### PR TITLE
fix: Bitcoin network displays correctly and add token icon support

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/pages/asset-exchange/OneClickExchangeFormIframe.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/asset-exchange/OneClickExchangeFormIframe.jsx
@@ -53,6 +53,40 @@ const code = `
                     }
                 }
 
+                // Add token aliases for wrapped/variant tokens
+                if (module.tokens && Array.isArray(module.tokens)) {
+                    const tokenAliases = [
+                        { original: 'ETH', aliases: ['WETH'] },
+                        { original: 'NEAR', aliases: ['wNEAR', 'GNEAR', 'NOEAR'] },
+                        { original: 'BTC', aliases: ['xBTC', 'cbBTC'] },
+                        { original: 'WBTC', aliases: ['xBTC', 'cbBTC'] },  // Also try WBTC as source
+                    ];
+
+                    tokenAliases.forEach(({ original, aliases }) => {
+                        const originalToken = module.tokens.find(t =>
+                            t.symbol.toUpperCase() === original.toUpperCase()
+                        );
+                        if (originalToken) {
+                            aliases.forEach(alias => {
+                                // Check if alias already exists
+                                const exists = module.tokens.some(t =>
+                                    t.symbol.toUpperCase() === alias.toUpperCase()
+                                );
+                                if (!exists) {
+                                    // Create a copy with the alias symbol
+                                    const aliasToken = {
+                                        ...originalToken,
+                                        symbol: alias,
+                                        name: alias + ' (using ' + original + ' icon)'
+                                    };
+                                    module.tokens.push(aliasToken);
+                                    console.log('Added "' + alias + '" as alias for ' + original + ' token');
+                                }
+                            });
+                        }
+                    });
+                }
+
                 // Check if both are loaded
                 if (window.web3IconsCore) {
                     loadTokenIcons();

--- a/instances/widgets.treasury-factory.near/widget/pages/asset-exchange/OneClickExchangeFormIframe.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/asset-exchange/OneClickExchangeFormIframe.jsx
@@ -41,6 +41,18 @@ const code = `
             import('https://cdn.jsdelivr.net/npm/@web3icons/common@0.11.12/dist/index.min.js').then(module => {
                 window.web3IconsCommon = module;
                 console.log('Web3Icons Common loaded with', module.networks?.length || 0, 'networks and', module.tokens?.length || 0, 'tokens');
+
+                // Add "btc" as an alias for Bitcoin network
+                if (module.networks && Array.isArray(module.networks)) {
+                    const bitcoinNetwork = module.networks.find(n => n.id === 'bitcoin');
+                    if (bitcoinNetwork) {
+                        // Create a copy with "btc" as the id
+                        const btcNetwork = { ...bitcoinNetwork, id: 'btc' };
+                        module.networks.push(btcNetwork);
+                        console.log('Added "btc" alias for Bitcoin network');
+                    }
+                }
+
                 // Check if both are loaded
                 if (window.web3IconsCore) {
                     loadTokenIcons();

--- a/instances/widgets.treasury-factory.near/widget/pages/asset-exchange/OneClickExchangeFormIframe.jsx
+++ b/instances/widgets.treasury-factory.near/widget/pages/asset-exchange/OneClickExchangeFormIframe.jsx
@@ -1045,6 +1045,7 @@ const code = `
                         img.src = token.icon || iconCache[token.symbol];
                         img.width = 30;
                         img.height = 30;
+                        img.className = "rounded-circle";
                         tokenInfo.appendChild(img);
                     } else {
                         // Add spacer div to maintain alignment
@@ -1123,6 +1124,7 @@ const code = `
                         img.src = iconCache[symbol];
                         img.width = 30;
                         img.height = 30;
+                        img.className = "rounded-circle";
                         tokenInfo.appendChild(img);
                     } else {
                         // Add spacer div to maintain alignment
@@ -1200,6 +1202,7 @@ const code = `
                         img.src = network.icon;
                         img.width = 30;
                         img.height = 30;
+                        img.className = "rounded-circle";
                         img.style.marginRight = "8px";
                         item.appendChild(img);
                     } else {
@@ -1233,7 +1236,7 @@ const code = `
                 if (token.icon || iconCache[token.symbol]) {
                     const img = document.createElement("img");
                     img.src = token.icon || iconCache[token.symbol];
-                    img.className = "token-icon";
+                    img.className = "token-icon rounded-circle";
                     img.style.width = "20px";
                     img.style.height = "20px";
                     img.style.marginRight = "8px";
@@ -1267,7 +1270,7 @@ const code = `
                 if (iconCache[symbol]) {
                     const img = document.createElement("img");
                     img.src = iconCache[symbol];
-                    img.className = "token-icon";
+                    img.className = "token-icon rounded-circle";
                     img.style.width = "20px";
                     img.style.height = "20px";
                     img.style.marginRight = "8px";
@@ -1303,13 +1306,13 @@ const code = `
                 if (networkIcon) {
                     const img = document.createElement("img");
                     img.src = networkIcon;
-                    img.className = "token-icon";
+                    img.className = "token-icon rounded-circle";
                     img.style.width = "20px";
                     img.style.height = "20px";
                     img.style.marginRight = "8px";
                     img.style.verticalAlign = "middle";
                     display.appendChild(img);
-                    
+
                     // Cache the icon for future use
                     if (!iconCache[network.id + "_network_icon"]) {
                         iconCache[network.id + "_network_icon"] = networkIcon;


### PR DESCRIPTION
## Summary
- Fixed Bitcoin network name display issue where "Btc" was shown instead of "Bitcoin"  
- Added proper network ID mapping for Web3Icons compatibility
- Made all token and network icons rounded to match deposit modal styling
- Added icon support for wrapped and variant tokens (WETH, wNEAR, xBTC, etc.)
- Enhanced test coverage for network name and icon display

<img width="401" height="485" alt="image" src="https://github.com/user-attachments/assets/1916774b-90c0-402a-9ffb-fbe261c7b8c5" />


## Problem
1. The OneClick Exchange form was displaying raw network IDs like "Btc" instead of human-readable names like "Bitcoin" because the 1Click API uses `btc:mainnet` while Web3Icons expects `bitcoin` as the network identifier
2. Many wrapped/variant tokens (WETH, wNEAR, xBTC, cbBTC) were showing without icons
3. Token and network icons were square instead of rounded like in the deposit modal

## Solution
1. Added a "btc" alias for the Bitcoin network when Web3Icons loads
2. Added token aliases to reuse existing token icons for wrapped variants:
   - WETH uses ETH icon
   - wNEAR, GNEAR, NOEAR use NEAR icon
   - xBTC, cbBTC use BTC/WBTC icons
3. Applied `rounded-circle` class to all icons for visual consistency

## Test plan
- [x] Run the Bitcoin network display test: `npx playwright test --project=treasury-testing playwright-tests/tests/intents/oneclick-exchange-form.spec.js --grep="Bitcoin"`
- [x] Test passes successfully verifying:
  - Bitcoin network shows as "Bitcoin" (not "Btc")
  - NEAR shows as "Near Protocol"  
  - Both networks display their correct icons
- [x] Manually tested in the OneClick Exchange form
- [x] Verified rounded icons match deposit modal styling
- [x] Verified wrapped tokens now show appropriate icons

Fixes #700

🤖 Generated with [Claude Code](https://claude.ai/code)