### PR TITLE
fix: Remove vote buttons instead of disabling on expired quotes

### DIFF
--- a/instances/widgets.treasury-factory.near/widget/components/VoteActions.jsx
+++ b/instances/widgets.treasury-factory.near/widget/components/VoteActions.jsx
@@ -352,7 +352,8 @@ return (
                 props={{
                   popup: (
                     <div>
-                      The 1Click API quote for this request expired on{" "}
+                      Voting is not available due to expired swap quote. The
+                      1Click API quote for this request expired on{" "}
                       {`${quoteDeadline.toLocaleString("en-US", {
                         month: "short",
                         day: "2-digit",
@@ -362,33 +363,19 @@ return (
                         hour12: true,
                         timeZone: "UTC",
                       })} UTC`}
-                      . Voting is disabled to prevent potential loss of funds
-                      from executing the swap at an outdated rate.
+                      . Executing the swap at an outdated rate could result in
+                      loss of funds.
                     </div>
                   ),
                   children: (
-                    <i
-                      className="bi bi-info-circle text-muted"
-                      style={{ cursor: "pointer" }}
-                    ></i>
+                    <span className="text-muted">
+                      <i className="bi bi-info-circle"></i> Voting not available
+                      due to expired swap quote
+                    </span>
                   ),
                   instance,
                 }}
               />
-              <button
-                className="btn btn-sm btn-success"
-                disabled
-                style={{ opacity: 0.5 }}
-              >
-                Approve
-              </button>
-              <button
-                className="btn btn-sm btn-danger"
-                disabled
-                style={{ opacity: 0.5 }}
-              >
-                Reject
-              </button>
             </div>
           ) : (
             // Full version for details page
@@ -396,8 +383,8 @@ return (
               <div className="d-flex align-items-center gap-2 text-muted flex-grow-1">
                 <i className="bi bi-info-circle"></i>
                 <span>
-                  Voting is no longer available. The 1Click API quote for this
-                  request expired on{" "}
+                  Voting is not available due to expired swap quote. The 1Click
+                  API quote for this request expired on{" "}
                   {`${quoteDeadline.toLocaleString("en-US", {
                     month: "short",
                     day: "2-digit",
@@ -415,8 +402,8 @@ return (
                       popup: (
                         <div>
                           The exchange rate quoted by 1Click API has expired.
-                          Voting is disabled to prevent potential loss of funds
-                          from executing the swap at an outdated rate.
+                          Executing the swap at an outdated rate could result in
+                          loss of funds.
                         </div>
                       ),
                       children: (
@@ -432,20 +419,6 @@ return (
                   />
                 </span>
               </div>
-              <button
-                className="btn btn-success"
-                disabled
-                style={{ opacity: 0.5 }}
-              >
-                Approve
-              </button>
-              <button
-                className="btn btn-danger"
-                disabled
-                style={{ opacity: 0.5 }}
-              >
-                Reject
-              </button>
             </div>
           )
         ) : !isReadyToBeWithdrawn ? (

--- a/playwright-tests/tests/intents/oneclick-exchange-details.spec.js
+++ b/playwright-tests/tests/intents/oneclick-exchange-details.spec.js
@@ -28,7 +28,7 @@ test.describe("OneClick Exchange Proposal Details", () => {
     await fs.mkdir(screenshotsDir, { recursive: true });
   });
 
-  test("disables voting when 1Click API quote is expired", async ({
+  test("removes voting buttons when 1Click API quote is expired", async ({
     page,
     instanceAccount,
     daoAccount,
@@ -123,7 +123,7 @@ test.describe("OneClick Exchange Proposal Details", () => {
     console.log(`Proposal #7 visible: ${proposalIdVisible}`);
 
     // Check that the expired quote message is displayed
-    const expiredMessage = page.getByText("Voting is no longer available");
+    const expiredMessage = page.getByText("Voting is not available due to expired swap quote");
     const messageVisible = await expiredMessage.isVisible().catch(() => false);
 
     if (messageVisible) {
@@ -138,33 +138,19 @@ test.describe("OneClick Exchange Proposal Details", () => {
         console.log("✓ Learn more link is visible");
       }
 
-      // Verify that vote buttons are disabled
+      // Verify that vote buttons are NOT visible (removed instead of disabled)
       const approveButton = page.getByRole("button", { name: "Approve" });
       const rejectButton = page.getByRole("button", { name: "Reject" });
 
-      const approveDisabled = await approveButton
-        .isDisabled()
+      const approveVisible = await approveButton
+        .isVisible()
         .catch(() => false);
-      const rejectDisabled = await rejectButton.isDisabled().catch(() => false);
+      const rejectVisible = await rejectButton.isVisible().catch(() => false);
 
-      if (approveDisabled && rejectDisabled) {
-        console.log("✓ Vote buttons are disabled");
+      if (!approveVisible && !rejectVisible) {
+        console.log("✓ Vote buttons are removed (not shown)");
       } else {
-        console.log("✗ Vote buttons are not disabled as expected");
-      }
-
-      // Check opacity if buttons exist
-      if ((await approveButton.count()) > 0) {
-        const approveOpacity = await approveButton.evaluate(
-          (el) => window.getComputedStyle(el).opacity
-        );
-        const rejectOpacity = await rejectButton.evaluate(
-          (el) => window.getComputedStyle(el).opacity
-        );
-
-        if (parseFloat(approveOpacity) < 1 && parseFloat(rejectOpacity) < 1) {
-          console.log("✓ Buttons have reduced opacity");
-        }
+        console.log("✗ Vote buttons are visible when they should be removed");
       }
 
       // Check that token symbols are displayed, not contract addresses
@@ -234,8 +220,8 @@ test.describe("OneClick Exchange Proposal Details", () => {
 
       // All checks passed
       expect(messageVisible).toBeTruthy();
-      expect(approveDisabled).toBeTruthy();
-      expect(rejectDisabled).toBeTruthy();
+      expect(approveVisible).toBeFalsy();
+      expect(rejectVisible).toBeFalsy();
     } else {
       // If the new implementation isn't working, log what we see
       console.log(
@@ -365,7 +351,7 @@ test.describe("OneClick Exchange Proposal Details", () => {
     await page.waitForTimeout(5000);
 
     // Check that the expired quote message is NOT displayed
-    const expiredMessage = page.getByText("Voting is no longer available");
+    const expiredMessage = page.getByText("Voting is not available due to expired swap quote");
     const messageVisible = await expiredMessage.isVisible().catch(() => false);
 
     expect(messageVisible).toBeFalsy();

--- a/playwright-tests/tests/intents/oneclick-exchange-details.spec.js
+++ b/playwright-tests/tests/intents/oneclick-exchange-details.spec.js
@@ -123,7 +123,9 @@ test.describe("OneClick Exchange Proposal Details", () => {
     console.log(`Proposal #7 visible: ${proposalIdVisible}`);
 
     // Check that the expired quote message is displayed
-    const expiredMessage = page.getByText("Voting is not available due to expired swap quote");
+    const expiredMessage = page.getByText(
+      "Voting is not available due to expired swap quote"
+    );
     const messageVisible = await expiredMessage.isVisible().catch(() => false);
 
     if (messageVisible) {
@@ -142,9 +144,7 @@ test.describe("OneClick Exchange Proposal Details", () => {
       const approveButton = page.getByRole("button", { name: "Approve" });
       const rejectButton = page.getByRole("button", { name: "Reject" });
 
-      const approveVisible = await approveButton
-        .isVisible()
-        .catch(() => false);
+      const approveVisible = await approveButton.isVisible().catch(() => false);
       const rejectVisible = await rejectButton.isVisible().catch(() => false);
 
       if (!approveVisible && !rejectVisible) {
@@ -351,7 +351,9 @@ test.describe("OneClick Exchange Proposal Details", () => {
     await page.waitForTimeout(5000);
 
     // Check that the expired quote message is NOT displayed
-    const expiredMessage = page.getByText("Voting is not available due to expired swap quote");
+    const expiredMessage = page.getByText(
+      "Voting is not available due to expired swap quote"
+    );
     const messageVisible = await expiredMessage.isVisible().catch(() => false);
 
     expect(messageVisible).toBeFalsy();

--- a/playwright-tests/tests/intents/vote-on-expired-quote-table.spec.js
+++ b/playwright-tests/tests/intents/vote-on-expired-quote-table.spec.js
@@ -14,7 +14,7 @@ test.describe("Asset Exchange Table - Expired Quote Handling", () => {
     storageState: "playwright-tests/storage-states/wallet-connected-admin.json",
   });
 
-  test("disables voting buttons for expired quotes in table view", async ({
+  test("removes voting buttons for expired quotes in table view", async ({
     page,
     instanceAccount,
     daoAccount,
@@ -196,43 +196,35 @@ test.describe("Asset Exchange Table - Expired Quote Handling", () => {
     if (expiredRowVisible) {
       console.log("✓ Found proposal #30 row");
 
-      // Check for the info icon in the actions column
-      const infoIcon = expiredRow.locator(".bi-info-circle");
-      const infoIconVisible = await infoIcon.isVisible().catch(() => false);
+      // Check for the expired quote message in the actions column
+      const expiredMessage = expiredRow.getByText(
+        "Voting not available due to expired swap quote"
+      );
+      const expiredMessageVisible = await expiredMessage
+        .isVisible()
+        .catch(() => false);
 
-      if (infoIconVisible) {
-        console.log("✓ Info icon is displayed for expired quote");
+      if (expiredMessageVisible) {
+        console.log("✓ Expired quote message is displayed");
 
-        // Hover over the info icon to see the tooltip
-        await infoIcon.hover();
+        // Hover over the message to see the tooltip
+        await expiredMessage.hover();
         await page.waitForTimeout(500);
 
-        // Check if the approve/reject buttons are disabled
+        // Check that approve/reject buttons are NOT visible (removed instead of disabled)
         const approveBtn = expiredRow.locator('button:has-text("Approve")');
         const rejectBtn = expiredRow.locator('button:has-text("Reject")');
 
-        const approveDisabled = await approveBtn
-          .isDisabled()
-          .catch(() => false);
-        const rejectDisabled = await rejectBtn.isDisabled().catch(() => false);
+        const approveVisible = await approveBtn.isVisible().catch(() => false);
+        const rejectVisible = await rejectBtn.isVisible().catch(() => false);
 
-        expect(approveDisabled).toBeTruthy();
-        expect(rejectDisabled).toBeTruthy();
-        console.log("✓ Voting buttons are disabled for expired quote");
-
-        // Check button opacity
-        const approveOpacity = await approveBtn.evaluate(
-          (el) => window.getComputedStyle(el).opacity
+        expect(approveVisible).toBeFalsy();
+        expect(rejectVisible).toBeFalsy();
+        console.log(
+          "✓ Voting buttons are removed (not shown) for expired quote"
         );
-        const rejectOpacity = await rejectBtn.evaluate(
-          (el) => window.getComputedStyle(el).opacity
-        );
-
-        expect(parseFloat(approveOpacity)).toBeLessThan(1);
-        expect(parseFloat(rejectOpacity)).toBeLessThan(1);
-        console.log("✓ Buttons have reduced opacity");
       } else {
-        console.log("✗ Info icon not found for expired quote");
+        console.log("✗ Expired quote message not found");
       }
     } else {
       console.log("✗ Proposal #30 row not found");
@@ -299,7 +291,7 @@ test.describe("Asset Exchange Table - Expired Quote Handling", () => {
     console.log("\nTable view expired quote test completed successfully!");
   });
 
-  test("clicking on expired quote row shows details with disabled voting", async ({
+  test("clicking on expired quote row shows details with removed voting buttons", async ({
     page,
     instanceAccount,
     daoAccount,
@@ -426,7 +418,7 @@ test.describe("Asset Exchange Table - Expired Quote Handling", () => {
     // The details panel is in the secondary layout
     const detailsPanel = page.locator(".layout-secondary.show");
     const expiredMessage = detailsPanel.getByText(
-      "Voting is no longer available"
+      "Voting is not available due to expired swap quote"
     );
     const messageVisible = await expiredMessage.isVisible().catch(() => false);
 
@@ -442,17 +434,17 @@ test.describe("Asset Exchange Table - Expired Quote Handling", () => {
       if (deadlineExpired) {
         console.log("✓ Quote deadline shown as expired in details");
       }
+    }
 
-      // Check if voting buttons are disabled in the details panel
-      const approveBtn = detailsPanel.getByRole("button", { name: "Approve" });
-      const rejectBtn = detailsPanel.getByRole("button", { name: "Reject" });
+    // Check that voting buttons are NOT visible in the details panel (removed instead of disabled)
+    const approveBtn = detailsPanel.getByRole("button", { name: "Approve" });
+    const rejectBtn = detailsPanel.getByRole("button", { name: "Reject" });
 
-      const approveDisabled = await approveBtn.isDisabled().catch(() => false);
-      const rejectDisabled = await rejectBtn.isDisabled().catch(() => false);
+    const approveVisible = await approveBtn.isVisible().catch(() => false);
+    const rejectVisible = await rejectBtn.isVisible().catch(() => false);
 
-      if (approveDisabled && rejectDisabled) {
-        console.log("✓ Voting buttons are disabled in details panel");
-      }
+    if (!approveVisible && !rejectVisible) {
+      console.log("✓ Voting buttons are removed (not shown) in details panel");
     }
 
     // Take a screenshot

--- a/playwright-tests/tests/intents/vote-on-expired-quote.spec.js
+++ b/playwright-tests/tests/intents/vote-on-expired-quote.spec.js
@@ -101,15 +101,17 @@ test.describe("Asset Exchange - Expired Quote Voting Prevention", () => {
     await page.waitForTimeout(5000);
 
     // Verify the expired quote message is displayed
-    const expiredMessage = page.getByText("Voting is no longer available");
+    const expiredMessage = page.getByText(
+      "Voting is not available due to expired swap quote"
+    );
     await expect(expiredMessage).toBeVisible();
 
-    // Verify vote buttons are disabled
+    // Verify vote buttons are NOT visible (removed instead of disabled)
     const approveButton = page.getByRole("button", { name: "Approve" });
     const rejectButton = page.getByRole("button", { name: "Reject" });
 
-    await expect(approveButton).toBeDisabled();
-    await expect(rejectButton).toBeDisabled();
+    await expect(approveButton).not.toBeVisible();
+    await expect(rejectButton).not.toBeVisible();
 
     // Verify the quote deadline shows as expired in the proposal content
     await expect(page.locator("text=Quote Deadline")).toBeVisible();
@@ -226,7 +228,9 @@ test.describe("Asset Exchange - Expired Quote Voting Prevention", () => {
     await page.waitForTimeout(5000);
 
     // Verify the expired quote message is NOT displayed
-    const expiredMessage = page.getByText("Voting is no longer available");
+    const expiredMessage = page.getByText(
+      "Voting is not available due to expired swap quote"
+    );
     await expect(expiredMessage).not.toBeVisible();
 
     // Verify vote buttons are ENABLED


### PR DESCRIPTION
## Summary
Fixes #680 by removing voting buttons instead of disabling them when NEAR Intents asset exchange quotes have expired, making the behavior consistent with the rest of the system.

<img width="791" height="474" alt="image" src="https://github.com/user-attachments/assets/81b2331f-b87d-4c9b-82c6-e21ba961e16d" />

## Changes
- Modified `VoteActions.jsx` to completely remove voting buttons when quote is expired
- Added informative message: "Voting is not available due to expired swap quote"
- Different display for table view (compact message) vs details page (full message with "Learn more" link)
- Updated tooltip text to explain why voting is disabled

## Test Plan
- [x] Updated `vote-on-expired-quote.spec.js` test to verify buttons are not visible instead of disabled
- [x] Updated `vote-on-expired-quote-table.spec.js` test for table view to verify the new message is shown
- [x] All 4 tests passing successfully

## Screenshots
Before: Voting buttons were shown as disabled with reduced opacity
After: Voting buttons are completely removed with an informative message explaining why

🤖 Generated with [Claude Code](https://claude.ai/code)